### PR TITLE
Fixing arrow icon on Query Tiles configuration template

### DIFF
--- a/src/AzureExtension/Widgets/Templates/AzureQueryTilesConfigurationTemplate.json
+++ b/src/AzureExtension/Widgets/Templates/AzureQueryTilesConfigurationTemplate.json
@@ -60,7 +60,7 @@
           "inlineAction": {
             "type": "Action.Execute",
             "verb": "Submit",
-            "iconUrl": "data:image/png;base64,${arrow}"
+            "iconUrl": "data:image/png;base64,${$root.arrow}"
           }
         },
         {


### PR DESCRIPTION
## Summary of the pull request
This pull request fixes the reference to the icon on query tiles configuration template. Now it shows correctly.
<img width="130" alt="image" src="https://github.com/microsoft/DevHomeAzureExtension/assets/13912953/f5e05696-b503-462e-b557-3a147a9a5e51">

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
