### PR TITLE
Fix intermittent logfile-in-use test failures

### DIFF
--- a/test/AzureExtension/Helpers/TestSetupHelpers.cs
+++ b/test/AzureExtension/Helpers/TestSetupHelpers.cs
@@ -11,7 +11,7 @@ public partial class TestHelpers
 {
     private const string DataBaseFileName = "AzureExtension-Test.db";
     private const string LogFileName = "AzureExtension-{now}.log";
-    private const int CleanupRetryWaitTime = 1000 * 10;         // 10 seconds.
+    private static readonly TimeSpan CleanupRetryWaitTime = TimeSpan.FromSeconds(10);
 
     public static void CleanupTempTestOptions(TestOptions options, TestContext context)
     {


### PR DESCRIPTION
## Summary of the pull request
The asynchronous logfile writing in tests can lead to a test finishing before the logfile writer is done writing to the log. Since the test cleanup occurs immediately after the test is done and I/O is naturally much slower (the whole reason it is asynchronous), this can lead to a race where the test is finished but the logfile is not, and attempting to cleanup the folder with the logfile results in an uncaught I/O exception. This fix handles those races by catching the first IOException during test cleanup, waiting several seconds, and then trying again to allow time for the logfile writer to finish.

## References and relevant issues
Closes https://github.com/microsoft/DevHomeADOExtension/issues/78

## Detailed description of the pull request / Additional comments
Added a catch IOException clause to the Test Cleanup so if we enconter an IOException while cleaning up, wait ten seconds and try again. The retry will not be caught so we can detect real issues that aren't logfile writing races.

## Validation steps performed

#  PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
