### PR TITLE
Fix crash when cloning a repo that does not have project in the URL.

### DIFF
--- a/src/AzureExtension/Providers/RepositoryProvider.cs
+++ b/src/AzureExtension/Providers/RepositoryProvider.cs
@@ -255,36 +255,32 @@ public class RepositoryProvider : IRepositoryProvider
                 return new RepositoryResult(exception, $"{exception.Message} HResult: {exception.HResult}");
             }
 
-            var authResult = DeveloperIdProvider.GetInstance().GetAuthenticationResultForDeveloperId(azureDeveloperId);
-            if (authResult == null)
-            {
-                var exception = new AuthenticationException($"Could not get authentication for user {developerId.LoginId}");
-                return new RepositoryResult(exception, $"Something went wrong.  HResult: {exception.HResult}");
-            }
-
-            var repoInformation = new RepositoryInformation(uri);
-            var connection = new VssConnection(repoInformation.OrganizationLink, new VssAadCredential(new VssAadToken("Bearer", authResult.AccessToken)));
-
-            GitHttpClient gitClient = connection.GetClient<GitHttpClient>();
-            var repo = gitClient.GetRepositoryAsync(repoInformation.Project, repoInformation.RepoName).Result;
-            if (repo == null)
-            {
-                var exception = new LibGit2Sharp.NotFoundException("Could not find the repo.");
-                return new RepositoryResult(exception, $"Something went wrong.  HResult: {exception.HResult}");
-            }
-
-            RepositoryResult repoResult;
-
             try
             {
-                repoResult = new RepositoryResult(new DevHomeRepository(repo));
+                var authResult = DeveloperIdProvider.GetInstance().GetAuthenticationResultForDeveloperId(azureDeveloperId);
+                if (authResult == null)
+                {
+                    var exception = new AuthenticationException($"Could not get authentication for user {developerId.LoginId}");
+                    return new RepositoryResult(exception, $"Something went wrong.  HResult: {exception.HResult}");
+                }
+
+                var repoInformation = new RepositoryInformation(uri);
+                var connection = new VssConnection(repoInformation.OrganizationLink, new VssAadCredential(new VssAadToken("Bearer", authResult.AccessToken)));
+
+                GitHttpClient gitClient = connection.GetClient<GitHttpClient>();
+                var repo = gitClient.GetRepositoryAsync(repoInformation.Project, repoInformation.RepoName).Result;
+                if (repo == null)
+                {
+                    var exception = new LibGit2Sharp.NotFoundException("Could not find the repo.");
+                    return new RepositoryResult(exception, $"Something went wrong.  HResult: {exception.HResult}");
+                }
+
+                return new RepositoryResult(new DevHomeRepository(repo));
             }
             catch (Exception e)
             {
                 return new RepositoryResult(e, $"Could not make a repository object");
             }
-
-            return repoResult;
         }).AsAsyncOperation();
     }
 


### PR DESCRIPTION
## Summary of the pull request
An uncaught exception can occur in the RepositoryProvider when given a valid Repository URI that does not have a project segment. 

## References and relevant issues
This fixes the _crash_ part of #31. It does not fix the scenario working, just stops the crash.

## Detailed description of the pull request / Additional comments
This is a case where the project and the repository have the same name and Azure makes a shorter URL by removing the project name. This led to an invalid request to GetRepositoryAsync(), which threw an exception that was uncaught.

The fix moves up a try-catch block to be larger than it was and include Azure GetRepository calls and DeveloperId calls which could throw and, if uncaught, crash the extension and DevHome.

## Validation steps performed
Followed instructions for scenario testing described here: https://github.com/microsoft/devhome/pull/1849

* Verified crash occurs without fix.
* Verified the crash scenario no longer crashes with the fix. (It is still not successful, but it does not crash, which is the point of the fix.)
* Verified cloning of a repository by URL
* Verified cloning of 3 different repositories as a batch in a different organization via the accounts.
* Verified error messages shown when it is invalid to clone something (no auth and repo already exists).

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
