### PR TITLE
Show all widget tiles in all widget sizes

### DIFF
--- a/src/AzureExtension/Widgets/Templates/AzureQueryTilesTemplate.json
+++ b/src/AzureExtension/Widgets/Templates/AzureQueryTilesTemplate.json
@@ -6,7 +6,6 @@
     {
       "type": "ColumnSet",
       "$data": "${lines}",
-      "$when": "${$index == 0 || ($index == 1 && $host.widgetSize != 'small') || ($index == 2 && $host.widgetSize == 'large')}",
       "spacing": "small",
       "columns": [
         {
@@ -44,7 +43,6 @@
           "backgroundImage": {
               "url": "data:image/png;base64,${backgroundImage}"
           },
-          "horizontalAlignment": "Left",
           "verticalContentAlignment": "Center",
           "spacing": "small",
           "style": "emphasis"


### PR DESCRIPTION
## Summary of the pull request
Instead of hiding tiles in the medium size, show all tiles. This indicates to the user that there's more content they will see if they choose a larger size. Otherwise, they can just scroll.
![image](https://github.com/microsoft/DevHomeAzureExtension/assets/47155823/9489e8cc-6a80-40be-9610-c01e785a8de3)

 Removed horizontalAlignment because it wasn't doing anything.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #15 
- [ ] Tests added/passed
- [ ] Documentation updated
