### PR TITLE
Prevent Tile widget from reverting back to configuration after cancel

### DIFF
--- a/src/AzureExtension/Widgets/AzureQueryTilesWidget.cs
+++ b/src/AzureExtension/Widgets/AzureQueryTilesWidget.cs
@@ -135,6 +135,7 @@ internal class AzureQueryTilesWidget : AzureWidget
                 // Put back the configuration data from before we started changing the widget.
                 ConfigurationData = SavedConfigurationData;
                 SavedConfigurationData = string.Empty;
+                CanPin = true;
 
                 // Tiles were updated on Submit, restore them from the saved configuration data.
                 UpdateAllTiles(ConfigurationData);


### PR DESCRIPTION
## Summary of the pull request
If we don't set CanPin back to true, next time the widget updates itself automatically it will think it needs to show the configuration page.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #36
- [ ] Tests added/passed
- [ ] Documentation updated
