### PR TITLE
Fix save bugs on Query Tiles Widget

### DIFF
--- a/src/AzureExtension/Widgets/AzureQueryTilesWidget.cs
+++ b/src/AzureExtension/Widgets/AzureQueryTilesWidget.cs
@@ -384,7 +384,6 @@ internal class AzureQueryTilesWidget : AzureWidget
                 {
                     // Uri was not changed by the user since the last update, so update the title
                     // if it is different, otherwise leave it alone so we only validate once.
-                    // We just update the title if it is not empty.
                     if (tile.Title != titleFromData)
                     {
                         tile.Title = titleFromData;


### PR DESCRIPTION
## Summary of the pull request
When the user is customizing an exiting Query Tiles widget, they can delete some tiles on the configuration screen, making it lose tiles on the actual widget and sometimes having the effect of making the last tile lose its title.

To fix that, we need to call the method to reset the number of tiles from a configuration data, and the method to validate the data when the user clicks to cancel the customization.
## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #26 
- [ ] Tests added/passed
- [ ] Documentation updated
