### PR TITLE
Adding implementation and test

### DIFF
--- a/src/AzureExtension/AzureExtension.cs
+++ b/src/AzureExtension/AzureExtension.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using AzureExtension.DevBox;
 using DevHomeAzureExtension.DeveloperId;
 using DevHomeAzureExtension.Providers;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Windows.DevHome.SDK;
 
@@ -35,7 +36,7 @@ public sealed class AzureExtension : IExtension
             case ProviderType.FeaturedApplications:
                 return new object();
             case ProviderType.ComputeSystem:
-                return new DevBoxProvider(_host);
+                return _host.Services.GetService<DevBoxProvider>();
             default:
                 Providers.Log.Logger()?.ReportInfo("Invalid provider");
                 return null;

--- a/src/AzureExtension/Services/DevBox/ManagementService.cs
+++ b/src/AzureExtension/Services/DevBox/ManagementService.cs
@@ -20,23 +20,71 @@ public class ManagementService : IDevBoxManagementService
     public ManagementService(IDevBoxAuthService authService) =>
         _authService = authService;
 
-    private static readonly string Query = " ";
+    private static readonly string Query =
+        "{\"query\": \"Resources | where type in~ ('microsoft.devcenter/projects') | where properties['provisioningState'] =~ 'Succeeded' | project id, location, tenantId, name, properties, type\"," +
+        " \"options\":{\"allowPartialScopes\":true}}";
 
     public IDeveloperId? DevId
     {
         get; set;
     }
 
-    public JsonElement GetAllProjectsAsJsonAsync()
+    public async Task<JsonElement> GetAllProjectsAsJsonAsync()
     {
         JsonElement result = default;
+        var httpManageClient = _authService.GetManagementClient(DevId);
+        if (httpManageClient != null)
+        {
+            var projectQuery = new HttpRequestMessage(HttpMethod.Post, "https://management.azure.com/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01");
+            projectQuery.Content = new StringContent(Query, Encoding.UTF8, "application/json");
+
+            // Make the request
+            var response = await httpManageClient.SendAsync(projectQuery);
+            var content = await response.Content.ReadAsStringAsync();
+            if (response.IsSuccessStatusCode && content.Length > 0)
+            {
+                var root = JsonDocument.Parse(content).RootElement;
+                root.TryGetProperty("data", out result);
+            }
+            else
+            {
+                Log.Logger()?.ReportError($"Error getting projects: {response.StatusCode} {content}");
+            }
+        }
+        else
+        {
+            Log.Logger()?.ReportError($"Error getting projects: httpManageClient is null");
+        }
 
         return result;
     }
 
-    public JsonElement GetBoxesAsJsonAsync(string devCenterUri, string project)
+    public async Task<JsonElement> GetBoxesAsJsonAsync(string devCenterUri, string project)
     {
         JsonElement result = default;
+        var httpDataClient = _authService.GetDataPlaneClient(DevId);
+        if (httpDataClient != null)
+        {
+            var api = devCenterUri + "projects/" + project + "/users/me/devboxes?api-version=2023-07-01-preview";
+            var boxQuery = new HttpRequestMessage(HttpMethod.Get, api);
+
+            // Make the request
+            var response = await httpDataClient.SendAsync(boxQuery);
+            var content = await response.Content.ReadAsStringAsync();
+            if (response.IsSuccessStatusCode && content.Length > 0)
+            {
+                var root = JsonDocument.Parse(content).RootElement;
+                root.TryGetProperty("value", out result);
+            }
+            else
+            {
+                Log.Logger()?.ReportError($"Error getting boxes: {response.StatusCode} {content}");
+            }
+        }
+        else
+        {
+            Log.Logger()?.ReportError($"Error getting boxes: httpDataClient is null");
+        }
 
         return result;
     }

--- a/src/AzureExtensionServer/Program.cs
+++ b/src/AzureExtensionServer/Program.cs
@@ -233,6 +233,7 @@ public sealed class Program
                 services.AddSingleton<IDevBoxAuthService, AuthService>();
                 services.AddSingleton<IArmTokenService, ArmTestTokenService>();
                 services.AddSingleton<IDataTokenService, DataTokenService>();
+                services.AddSingleton<DevBoxProvider>();
                 services.AddTransient<DevBoxInstance>();
             }).
         Build();

--- a/test/AzureExtension/AzureExtension.Test.csproj
+++ b/test/AzureExtension/AzureExtension.Test.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.100.323" />
+    <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />

--- a/test/AzureExtension/DevBox/DevBoxTests.cs
+++ b/test/AzureExtension/DevBox/DevBoxTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using AzureExtension.Contracts;
+using AzureExtension.DevBox;
+using AzureExtension.Services.DevBox;
+using AzureExtension.Test.DevBox;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace DevHomeAzureExtension.Test;
+
+public partial class DevBoxTests
+{
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DevBox_MockHTTPCalls()
+    {
+        // Arrange
+        var host = Microsoft.Extensions.Hosting.Host.
+            CreateDefaultBuilder().
+            UseContentRoot(AppContext.BaseDirectory).
+            UseDefaultServiceProvider((context, options) =>
+            {
+                options.ValidateOnBuild = true;
+            }).
+            ConfigureServices((context, services) =>
+            {
+                services.AddSingleton<IHttpClientFactory>(mockFactory.Object);
+                services.AddSingleton<HttpClient>(mockHttpClient);
+                services.AddSingleton<IDevBoxManagementService, ManagementService>();
+                services.AddSingleton<IDevBoxAuthService, AuthService>();
+                services.AddSingleton<IArmTokenService, ArmTestTokenService>();
+                services.AddSingleton<IDataTokenService, DataTestTokenService>();
+                services.AddSingleton<DevBoxProvider>();
+                services.AddTransient<DevBoxInstance>();
+            }).
+            Build();
+
+        // Act
+        var instance = host.Services.GetService<DevBoxProvider>();
+        var systems = instance?.GetComputeSystemsAsync(null).Result;
+
+        // Assert
+        Assert.IsTrue(systems?.Any());
+    }
+}

--- a/test/AzureExtension/DevBox/DevBoxTestsSetup.cs
+++ b/test/AzureExtension/DevBox/DevBoxTestsSetup.cs
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System.Net;
+using Moq;
+using Moq.Protected;
+
+namespace DevHomeAzureExtension.Test;
+
+[TestClass]
+public partial class DevBoxTests : IDisposable
+{
+    private readonly Mock<IHttpClientFactory> mockFactory = new();
+
+    public TestContext? TestContext
+    {
+        get; set;
+    }
+
+    private TestOptions testOptions = new();
+
+    private TestOptions TestOptions
+    {
+        get => testOptions;
+        set => testOptions = value;
+    }
+
+    private const string MockTestJson =
+            @"{
+            ""totalRecords"": 10,
+            ""count"": 10,
+            ""data"": [
+            {
+              ""id"": ""/subscriptions/beedbc7420-fb03-44af-daac-69d8ff6e4e8c/resourceGroups/sales_devbox_rg/providers/Microsoft.DevCenter/projects/DevBoxUnitTestProject"",
+              ""location"": ""westus3"",
+              ""tenantId"": ""72f999bf-86f1-41af-96fc-2d7beef3db47"",
+              ""name"": ""DevBoxUnitTestProject"",
+              ""properties"": {
+                ""provisioningState"": ""Succeeded"",
+                ""description"": ""Plain devbox, just VS 2022, tools,  no enlistment"",
+                ""devCenterUri"": ""https://72f98fab-86f1-41af-69ab-2dbeef11db47-Salesdevcenter.devcenter.azure.com/"",
+                ""devCenterId"": ""/subscriptions/beedbc7420-fb03-44af-daac-69d8ff6e4e8c/resourceGroups/sales_devbox_rg/providers/Microsoft.DevCenter/devcenters/SalesDevCenter""
+              },
+              ""type"": ""microsoft.devcenter/projects""
+            }
+            ],
+                ""value"": [
+                {
+                    ""uri"": ""https://72f9feed-86f1-41af-91ab-beefd011db47-devcenter-dc.westus3.devcenter.azure.com/projects/nonprod/users/28feedaeb-996b-434b-bb57-4969cbeef8f0/devboxes/two"",
+                    ""name"": ""Two"",
+                    ""projectName"": ""Nonprod"",
+                    ""poolName"": ""Some-Enhanced-Pool-In-Da-West"",
+                    ""hibernateSupport"": ""Disabled"",
+                    ""provisioningState"": ""Succeeded"",
+                    ""actionState"": ""Stopped"",
+                    ""powerState"": ""Deallocated"",
+                    ""uniqueId"": ""28feedaeb-996b-434b-bb57-4969cbeef8f0"",
+                    ""location"": ""westus2"",
+                    ""osType"": ""Windows"",
+                    ""user"": ""28feedaeb-996b-434b-bb57-4969cbeef8f0"",
+                    ""hardwareProfile"": {
+                    ""vCPUs"": 16,
+                    ""skuName"": ""some_sku_v2"",
+                    ""memoryGB"": 64
+                    },
+                    ""storageProfile"": {
+                    ""osDisk"": {
+                        ""diskSizeGB"": 2048
+                    }
+                    },
+                    ""imageReference"": {
+                    ""name"": ""1es-office-enhancedtools-baseImage"",
+                    ""version"": ""2023.0608.0"",
+                    ""operatingSystem"": ""Windows 11 Enterprise"",
+                    ""osBuildNumber"": ""22H2"",
+                    ""publishedDate"": ""2023-06-08T19:48:22.7178982+00:00""
+                    },
+                    ""createdTime"": ""2023-08-22T19:06:51.0750942+00:00"",
+                    ""localAdministrator"": ""Enabled""
+                }
+                ],
+            ""facets"": [],
+            ""resultTruncated"": ""false"",
+            ""rdpConnectionUrl"": ""https://sample.uri.com"",
+            ""webUrl"": ""https://sample.uri.com""
+        }";
+
+    private HttpClient mockHttpClient = new();
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        TestOptions = TestHelpers.SetupTempTestOptions(TestContext!);
+
+        // Create a mock HttpMessageHandler
+        var handlerMock = new Mock<HttpMessageHandler>();
+
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(MockTestJson),
+            });
+
+        // Create an HttpClient using the mocked handler
+        mockHttpClient = new HttpClient(handlerMock.Object);
+
+        mockFactory.Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(mockHttpClient);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        TestHelpers.CleanupTempTestOptions(TestOptions, TestContext!);
+    }
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
## Summary of the pull request
This PR adds Dev Box functionality to the extension. Dev Boxes are cloud VMs offered by Microsoft. This PR is part of changes that will enable Dev Home to list and control Dev Boxes.

## Detailed description of the pull request / Additional comments
This PR adds the actual implementation for the skeleton methods added as part of the[ framework PR](https://github.com/microsoft/DevHomeAzureExtension/pull/51). Ther implementation includes enumerating all the dev boxes, and their starting, stopping, deleting and restarting.

Diagram idea credit @bbonaby 
```mermaid
sequenceDiagram
    Dev Home->>AzureExt(DevBoxProvider): GetComputeSystemsAsync()
    AzureExt(DevBoxProvider)->>ManagementService: Get all dev center projects for user
	ManagementService->>AuthenticationService: Get HTTP Client to use
	AuthenticationService->>TokenService: Get token to use
	TokenService-->>AuthenticationService: Returns AzureResourceManager token
	AuthenticationService-->>ManagementService: Returns HTTP Client w/ ARM token	
	ManagementService-->>AzureExt(DevBoxProvider): Returns projects
	AzureExt(DevBoxProvider)->>ManagementService: Get all dev boxes under project
	ManagementService->>AuthenticationService: Get HTTP Client to use
	AuthenticationService->>TokenService: Get token to use
	TokenService-->>AuthenticationService: Returns Data Plane token
	AuthenticationService-->>ManagementService: Returns Client w/ Data Plane token	
	ManagementService-->>AzureExt(DevBoxProvider): Returns Dev Boxes	
	AzureExt(DevBoxProvider)->>ManagementService: Get dev boxes' details
	ManagementService->>AuthenticationService: Get HTTP Client to use
	AuthenticationService-->>ManagementService: Returns Client w/ Data Plane token	
	ManagementService-->>AzureExt(DevBoxProvider): Returns details
    AzureExt(DevBoxProvider)-)Dev Home: Returns List of IComputeSystems
```

## Validation steps performed
Unit Tests
Manual validation

## Note: Currently the PR doesn't build since it uses a SDK that has ComputeSystem changes as needed for this feature.