### PR TITLE
Stopping x86 builds

### DIFF
--- a/.github/workflows/ADOExt-CI.yml
+++ b/.github/workflows/ADOExt-CI.yml
@@ -13,15 +13,13 @@ jobs:
     strategy:
       matrix:
         configuration: [Release, Debug]
-        platform: [x64, x86, arm64]
+        platform: [x64, arm64]
         os: [windows-latest]
         dotnet-version: ['6.0.x']
         exclude:
         - configuration: Debug
           platform: x64
         - configuration: Release
-          platform: x86
-        - configuration: Debug
           platform: arm64
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Summary of the pull request
x86 build machines have an issue with missing .Net 6 dependencies.  Removing x86 builds.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
