### PR TITLE
Disable unittests for x86

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -202,26 +202,26 @@ extends:
                 AzureServicesAuthConnectionString: $(ApiScanConnectionString)
 
             - task: Windows Application Driver@0
-              condition: and(always(), ne('${{ platform}}', 'arm64'))
+              condition: and(always(), eq('${{ platform}}', 'x64'))
               inputs:
                 OperationType: 'Start'
 
             - task: PowerShell@2
               displayName: 'Run Unittests'
-              condition: ne('${{ platform}}', 'arm64')
+              condition: eq('${{ platform}}', 'x64')
               retryCountOnTaskFailure: 2
               inputs:
                 filePath: 'build/scripts/Test.ps1'
                 arguments: -Platform "${{ platform }}" -Configuration "${{ configuration }}" -IsAzurePipelineBuild
 
             - task: Windows Application Driver@0
-              condition: and(always(), ne('${{ platform}}', 'arm64'))
+              condition: and(always(), eq('${{ platform}}', 'x64'))
               inputs:
                 OperationType: 'Stop'
 
             - task: PublishTestResults@2
               displayName: 'Add Test Results to Azure'
-              condition: and(always(), ne('${{ platform}}', 'arm64'))
+              condition: and(always(), eq('${{ platform}}', 'x64'))
               inputs:
                 testResultsFormat: 'VSTest'
                 testResultsFiles: '*.trx'
@@ -254,7 +254,7 @@ extends:
                 sbomPackageVersion: $(MSIXVersion)
               - output: pipelineArtifact
                 displayName: 'Publish Test Results'
-                condition: and(always(), ne('${{ platform}}', 'arm64'))
+                condition: and(always(), eq('${{ platform}}', 'x64'))
                 artifactName: TestResults_${{ platform }}_${{ configuration }}
                 targetPath: $(testOutputArtifactDir)
                 sbomPackageName: devhomeazure.testresults


### PR DESCRIPTION
## Summary of the pull request
x86 pipelines are having issues with being unable to install .NET6.  This is a build action issue outside of this code.  However, this is preventing our builds from succeeding so disabling for now until the build action is fixed.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
