### PR TITLE
[DeveloperId]: Add unit tests for feature area

### DIFF
--- a/src/AzureExtension/DeveloperId/AuthenticationHelper.cs
+++ b/src/AzureExtension/DeveloperId/AuthenticationHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
+using System.Globalization;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Extensions.Msal;
 using Microsoft.IdentityModel.Abstractions;
@@ -43,15 +44,14 @@ public class AuthenticationHelper : IAuthenticationHelper
         InitializePublicClientAppForWAMBrokerAsync();
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "Globalization not required as the strings are not being displayed to user and are used in initialization")]
     public void InitializePublicClientApplicationBuilder()
     {
         MicrosoftEntraIdSettings.InitializeSettings();
         Log.Logger()?.ReportInfo($"Initialized MicrosoftEntraIdSettings");
 
         PublicClientApplicationBuilder = PublicClientApplicationBuilder.Create(MicrosoftEntraIdSettings.ClientId)
-           .WithAuthority(string.Format(MicrosoftEntraIdSettings.Authority, MicrosoftEntraIdSettings.TenantId))
-           .WithRedirectUri(string.Format(MicrosoftEntraIdSettings.RedirectURI, MicrosoftEntraIdSettings.ClientId))
+           .WithAuthority(string.Format(CultureInfo.InvariantCulture, MicrosoftEntraIdSettings.Authority, MicrosoftEntraIdSettings.TenantId))
+           .WithRedirectUri(string.Format(CultureInfo.InvariantCulture, MicrosoftEntraIdSettings.RedirectURI, MicrosoftEntraIdSettings.ClientId))
            .WithLogging(new MSALLogger(EventLogLevel.Warning), enablePiiLogging: false)
            .WithClientCapabilities(new string[] { "cp1" });
         Log.Logger()?.ReportInfo($"Created PublicClientApplicationBuilder");

--- a/src/AzureExtension/DeveloperId/AuthenticationHelper.cs
+++ b/src/AzureExtension/DeveloperId/AuthenticationHelper.cs
@@ -8,11 +8,11 @@ using Microsoft.UI;
 
 namespace DevHomeAzureExtension.DeveloperId;
 
-public class AuthenticationHelper
+public class AuthenticationHelper : IAuthenticationHelper
 {
     public AuthenticationSettings MicrosoftEntraIdSettings
     {
-        get; private set;
+        get; set;
     }
 
     private PublicClientApplicationBuilder? PublicClientApplicationBuilder
@@ -34,20 +34,27 @@ public class AuthenticationHelper
 
     public static Guid TransferTenetId { get; } = new("f8cdef31-a31e-4b4a-93e4-5f571e91255a");
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "Globalization not required as the strings are not being displayed to user and are used in initialization")]
     public AuthenticationHelper()
     {
         MicrosoftEntraIdSettings = new AuthenticationSettings();
+
+        InitializePublicClientApplicationBuilder();
+
+        InitializePublicClientAppForWAMBrokerAsync();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "Globalization not required as the strings are not being displayed to user and are used in initialization")]
+    public void InitializePublicClientApplicationBuilder()
+    {
+        MicrosoftEntraIdSettings.InitializeSettings();
         Log.Logger()?.ReportInfo($"Initialized MicrosoftEntraIdSettings");
 
         PublicClientApplicationBuilder = PublicClientApplicationBuilder.Create(MicrosoftEntraIdSettings.ClientId)
-            .WithAuthority(string.Format(MicrosoftEntraIdSettings.Authority, MicrosoftEntraIdSettings.TenantId))
-            .WithRedirectUri(string.Format(MicrosoftEntraIdSettings.RedirectURI, MicrosoftEntraIdSettings.ClientId))
-            .WithLogging(new MSALLogger(EventLogLevel.Warning), enablePiiLogging: false)
-            .WithClientCapabilities(new string[] { "cp1" });
+           .WithAuthority(string.Format(MicrosoftEntraIdSettings.Authority, MicrosoftEntraIdSettings.TenantId))
+           .WithRedirectUri(string.Format(MicrosoftEntraIdSettings.RedirectURI, MicrosoftEntraIdSettings.ClientId))
+           .WithLogging(new MSALLogger(EventLogLevel.Warning), enablePiiLogging: false)
+           .WithClientCapabilities(new string[] { "cp1" });
         Log.Logger()?.ReportInfo($"Created PublicClientApplicationBuilder");
-
-        InitializePublicClientAppForWAMBrokerAsync();
     }
 
     public async void InitializePublicClientAppForWAMBrokerAsync()
@@ -186,8 +193,8 @@ public class AuthenticationHelper
         }
         catch (Exception ex)
         {
-           // This is best effort
-           Log.Logger()?.ReportInfo($"Azure SSO failed with exception:{ex}");
+            // This is best effort
+            Log.Logger()?.ReportInfo($"Azure SSO failed with exception:{ex}");
         }
 
         return null;

--- a/src/AzureExtension/DeveloperId/AuthenticationSettings.cs
+++ b/src/AzureExtension/DeveloperId/AuthenticationSettings.cs
@@ -50,6 +50,17 @@ public class AuthenticationSettings
 
     public AuthenticationSettings()
     {
+        Authority = string.Empty;
+        ClientId = string.Empty;
+        TenantId = string.Empty;
+        RedirectURI = string.Empty;
+        CacheFileName = string.Empty;
+        CacheDir = string.Empty;
+        Scopes = string.Empty;
+    }
+
+    public void InitializeSettings()
+    {
         Authority = "https://login.microsoftonline.com/organizations";
         ClientId = "318b152a-4c0e-4050-879d-5e98031c4ccf";
         TenantId = string.Empty;

--- a/src/AzureExtension/DeveloperId/DeveloperIdProvider.cs
+++ b/src/AzureExtension/DeveloperId/DeveloperIdProvider.cs
@@ -21,7 +21,7 @@ public class DeveloperIdProvider : IDeveloperIdProvider
         get; set;
     }
 
-    private AuthenticationHelper DeveloperIdAuthenticationHelper
+    private IAuthenticationHelper DeveloperIdAuthenticationHelper
     {
         get; set;
     }
@@ -36,7 +36,7 @@ public class DeveloperIdProvider : IDeveloperIdProvider
     public string DisplayName => "Azure";
 
     // Private constructor for Singleton class.
-    private DeveloperIdProvider()
+    private DeveloperIdProvider(IAuthenticationHelper authHelper)
     {
         Log.Logger()?.ReportInfo($"Creating DeveloperIdProvider singleton instance");
 
@@ -44,7 +44,7 @@ public class DeveloperIdProvider : IDeveloperIdProvider
         {
             DeveloperIds ??= new List<DeveloperId>();
 
-            DeveloperIdAuthenticationHelper = new AuthenticationHelper();
+            DeveloperIdAuthenticationHelper = authHelper;
 
             // Retrieve and populate Logged in DeveloperIds from previous launch.
             RestoreDeveloperIds(DeveloperIdAuthenticationHelper.GetAllStoredLoginIdsAsync());
@@ -89,11 +89,13 @@ public class DeveloperIdProvider : IDeveloperIdProvider
         return new DeveloperIdsResult(null, "No account remediation required");
     }
 
-    public static DeveloperIdProvider GetInstance()
+    public static DeveloperIdProvider GetInstance(IAuthenticationHelper? authHelper = null)
     {
+        authHelper ??= new AuthenticationHelper();
+
         lock (AuthenticationProviderLock)
         {
-            singletonDeveloperIdProvider ??= new DeveloperIdProvider();
+            singletonDeveloperIdProvider ??= new DeveloperIdProvider(authHelper);
         }
 
         return singletonDeveloperIdProvider;

--- a/src/AzureExtension/DeveloperId/DeveloperIdProvider.cs
+++ b/src/AzureExtension/DeveloperId/DeveloperIdProvider.cs
@@ -36,7 +36,7 @@ public class DeveloperIdProvider : IDeveloperIdProvider
     public string DisplayName => "Azure";
 
     // Private constructor for Singleton class.
-    private DeveloperIdProvider(IAuthenticationHelper authHelper)
+    private DeveloperIdProvider(IAuthenticationHelper authenticationHelper)
     {
         Log.Logger()?.ReportInfo($"Creating DeveloperIdProvider singleton instance");
 
@@ -44,7 +44,7 @@ public class DeveloperIdProvider : IDeveloperIdProvider
         {
             DeveloperIds ??= new List<DeveloperId>();
 
-            DeveloperIdAuthenticationHelper = authHelper;
+            DeveloperIdAuthenticationHelper = authenticationHelper;
 
             // Retrieve and populate Logged in DeveloperIds from previous launch.
             RestoreDeveloperIds(DeveloperIdAuthenticationHelper.GetAllStoredLoginIdsAsync());
@@ -89,13 +89,13 @@ public class DeveloperIdProvider : IDeveloperIdProvider
         return new DeveloperIdsResult(null, "No account remediation required");
     }
 
-    public static DeveloperIdProvider GetInstance(IAuthenticationHelper? authHelper = null)
+    public static DeveloperIdProvider GetInstance(IAuthenticationHelper? authenticationHelper = null)
     {
-        authHelper ??= new AuthenticationHelper();
+        authenticationHelper ??= new AuthenticationHelper();
 
         lock (AuthenticationProviderLock)
         {
-            singletonDeveloperIdProvider ??= new DeveloperIdProvider(authHelper);
+            singletonDeveloperIdProvider ??= new DeveloperIdProvider(authenticationHelper);
         }
 
         return singletonDeveloperIdProvider;

--- a/src/AzureExtension/DeveloperId/IAuthenticationHelper.cs
+++ b/src/AzureExtension/DeveloperId/IAuthenticationHelper.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using Microsoft.Identity.Client;
+using Microsoft.UI;
+using Microsoft.Windows.DevHome.SDK;
+using Windows.Foundation;
+
+namespace DevHomeAzureExtension.DeveloperId;
+
+public interface IAuthenticationHelper
+{
+    public AuthenticationSettings MicrosoftEntraIdSettings
+    {
+        get; set;
+    }
+
+    public void InitializePublicClientApplicationBuilder();
+
+    public void InitializePublicClientAppForWAMBrokerAsync();
+
+    public Task<IEnumerable<string>> GetAllStoredLoginIdsAsync();
+
+    public Task InitializePublicClientAppForWAMBrokerAsyncWithParentWindow(WindowId? windowPtr);
+
+    public Task<IAccount?> LoginDeveloperAccount(string[] scopes);
+
+    public Task SignOutDeveloperIdAsync(string username);
+
+    public Task<IAccount?> AcquireWindowsAccountTokenSilently(string[] scopes);
+
+    public Task<IEnumerable<string>> AcquireAllDeveloperAccountTokens(string[] scopes);
+
+    public Task<AuthenticationResult?> ObtainTokenForLoggedInDeveloperAccount(string[] scopes, string loginId);
+}

--- a/src/AzureExtension/DeveloperId/IAuthenticationSettings.cs
+++ b/src/AzureExtension/DeveloperId/IAuthenticationSettings.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+namespace DevHomeAzureExtension.DeveloperId;
+
+public interface IAuthenticationSettings
+{
+    public void InitializeSettings();
+}

--- a/test/AzureExtension/DeveloperId/DeveloperIdProviderTests.cs
+++ b/test/AzureExtension/DeveloperId/DeveloperIdProviderTests.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using AzureExtension.Test.DeveloperId.Mocks;
+using DevHomeAzureExtension.DeveloperId;
+using Microsoft.Windows.DevHome.SDK;
+
+namespace DevHomeAzureExtension.Test;
+
+public partial class DeveloperIdTests
+{
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_AuthenticationExperienceKind()
+    {
+        // dependency injection
+        var devIdProvider = DeveloperIdProvider.GetInstance(new MockAuthenticationHelper());
+        Assert.IsNotNull(devIdProvider);
+        Assert.AreEqual(AuthenticationExperienceKind.CustomProvider, devIdProvider.GetAuthenticationExperienceKind());
+    }
+}

--- a/test/AzureExtension/DeveloperId/DeveloperIdProviderTests.cs
+++ b/test/AzureExtension/DeveloperId/DeveloperIdProviderTests.cs
@@ -11,11 +11,182 @@ public partial class DeveloperIdTests
 {
     [TestMethod]
     [TestCategory("Unit")]
+    public void DeveloperIdProvider_SingletonTest()
+    {
+        // Ensure that the DeveloperIdProvider is a singleton
+        var developerIdProvider1 = DeveloperIdProvider.GetInstance(new MockAuthenticationHelper());
+        Assert.IsNotNull(developerIdProvider1);
+        Assert.IsInstanceOfType(developerIdProvider1, typeof(DeveloperIdProvider));
+
+        var developerIdProvider2 = DeveloperIdProvider.GetInstance(new MockAuthenticationHelper());
+        Assert.IsNotNull(developerIdProvider2);
+        Assert.IsInstanceOfType(developerIdProvider2, typeof(DeveloperIdProvider));
+
+        Assert.AreSame(developerIdProvider1, developerIdProvider2);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
     public void DeveloperIdProvider_AuthenticationExperienceKind()
     {
         // dependency injection
-        var devIdProvider = DeveloperIdProvider.GetInstance(new MockAuthenticationHelper());
-        Assert.IsNotNull(devIdProvider);
-        Assert.AreEqual(AuthenticationExperienceKind.CustomProvider, devIdProvider.GetAuthenticationExperienceKind());
+        var developerIdProvider = DeveloperIdProvider.GetInstance(new MockAuthenticationHelper());
+        Assert.IsNotNull(developerIdProvider);
+        Assert.AreEqual(AuthenticationExperienceKind.CustomProvider, developerIdProvider.GetAuthenticationExperienceKind());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_GetDeveloperIds_Empty()
+    {
+        Task.Run(() =>
+        {
+            var mockAuthenticationHelper = new MockAuthenticationHelper();
+            var developerIdProvider = DeveloperIdProvider.GetInstance(mockAuthenticationHelper);
+
+            Assert.IsNotNull(developerIdProvider);
+
+            var result = developerIdProvider.GetLoggedInDeveloperIds();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(ProviderOperationStatus.Success, result.Result.Status);
+            Assert.AreEqual(0, result.DeveloperIds.Count());
+
+            developerIdProvider.Dispose();
+        });
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_GetDeveloperIds_NotEmpty()
+    {
+        Task.Run(() =>
+        {
+            var mockAuthenticationHelper = new MockAuthenticationHelper();
+            mockAuthenticationHelper.PopulateCache();
+            var developerIdProvider = DeveloperIdProvider.GetInstance(mockAuthenticationHelper);
+            Assert.IsNotNull(developerIdProvider);
+
+            var result = developerIdProvider.GetLoggedInDeveloperIds();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(ProviderOperationStatus.Success, result.Result.Status);
+            Assert.AreEqual(1, result.DeveloperIds.Count());
+            Assert.AreEqual("testAccount", result.DeveloperIds.First().LoginId);
+            developerIdProvider.Dispose();
+        });
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_GetDeveloperIdState_LoggedIn()
+    {
+        Task.Run(() =>
+        {
+            var mockAuthenticationHelper = new MockAuthenticationHelper();
+            mockAuthenticationHelper.PopulateCache();
+            var developerIdProvider = DeveloperIdProvider.GetInstance(mockAuthenticationHelper);
+            Assert.IsNotNull(developerIdProvider);
+
+            var result = developerIdProvider.GetLoggedInDeveloperIds();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(ProviderOperationStatus.Success, result.Result.Status);
+            Assert.AreEqual(1, result.DeveloperIds.Count());
+            Assert.AreEqual("testAccount", result.DeveloperIds.First().LoginId);
+
+            var developerIdStateResult = developerIdProvider.GetDeveloperIdState(result.DeveloperIds.First());
+            Assert.IsNotNull(result);
+            Assert.AreEqual(AuthenticationState.LoggedIn, developerIdStateResult);
+            developerIdProvider.Dispose();
+        });
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_GetDeveloperIdState_LoggedOut()
+    {
+        Task.Run(() =>
+        {
+            var developerIdProvider = DeveloperIdProvider.GetInstance();
+            Assert.IsNotNull(developerIdProvider);
+
+            var result = developerIdProvider.GetDeveloperIdState(new DeveloperId.DeveloperId());
+            Assert.IsNotNull(result);
+            Assert.AreEqual(AuthenticationState.LoggedOut, result);
+        });
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_ShowLogonSession()
+    {
+        Task.Run(async () =>
+        {
+            var developerIdProvider = DeveloperIdProvider.GetInstance(new MockAuthenticationHelper());
+            Assert.IsNotNull(developerIdProvider);
+
+            var result = await developerIdProvider.ShowLogonSession(default(Microsoft.UI.WindowId));
+            Assert.IsNotNull(result);
+            Assert.AreEqual(ProviderOperationStatus.Success, result.Result.Status);
+        });
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_LogoutDeveloperId_Success()
+    {
+        Task.Run(() =>
+        {
+            var mockAuthenticationHelper = new MockAuthenticationHelper();
+            mockAuthenticationHelper.PopulateCache();
+            var developerIdProvider = DeveloperIdProvider.GetInstance(mockAuthenticationHelper);
+            Assert.IsNotNull(developerIdProvider);
+
+            var resultForGetLoggedInDeveloperIds = developerIdProvider.GetLoggedInDeveloperIds();
+            Assert.IsNotNull(resultForGetLoggedInDeveloperIds);
+            Assert.AreEqual(ProviderOperationStatus.Success, resultForGetLoggedInDeveloperIds.Result.Status);
+            Assert.AreEqual(1, resultForGetLoggedInDeveloperIds.DeveloperIds.Count());
+            var developerIdToLogout = resultForGetLoggedInDeveloperIds.DeveloperIds.First();
+            Assert.IsNotNull(developerIdToLogout);
+
+            var resultForLogoutDeveloperId = developerIdProvider.LogoutDeveloperId(developerIdToLogout);
+            Assert.IsNotNull(resultForLogoutDeveloperId);
+            Assert.AreEqual(ProviderOperationStatus.Success, resultForLogoutDeveloperId.Status);
+            Assert.AreEqual(AuthenticationState.LoggedOut, developerIdProvider.GetDeveloperIdState(developerIdToLogout));
+
+            developerIdProvider.Dispose();
+        });
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_LogoutDeveloperId_InvalidDeveloperId()
+    {
+        Task.Run(() =>
+        {
+            var developerIdProvider = DeveloperIdProvider.GetInstance();
+            Assert.IsNotNull(developerIdProvider);
+
+            var result = developerIdProvider.LogoutDeveloperId(new DeveloperId.DeveloperId());
+            Assert.IsNotNull(result);
+            Assert.AreEqual(ProviderOperationStatus.Failure, result.Status);
+        });
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_DeveloperIdProvider_GetLoginAdaptiveCardSession_NeverImplemented()
+    {
+        var developerIdProvider = DeveloperIdProvider.GetInstance(new MockAuthenticationHelper());
+        Assert.IsNotNull(developerIdProvider);
+        AdaptiveCardSessionResult? result = null;
+        try
+        {
+            result = developerIdProvider.GetLoginAdaptiveCardSession();
+        }
+        catch (Exception e)
+        {
+            Assert.IsInstanceOfType(e, typeof(NotImplementedException));
+        }
+
+        Assert.IsNull(result);
     }
 }

--- a/test/AzureExtension/DeveloperId/DeveloperIdProviderTests.cs
+++ b/test/AzureExtension/DeveloperId/DeveloperIdProviderTests.cs
@@ -173,7 +173,7 @@ public partial class DeveloperIdTests
 
     [TestMethod]
     [TestCategory("Unit")]
-    public void DeveloperIdProvider_DeveloperIdProvider_GetLoginAdaptiveCardSession_NeverImplemented()
+    public void DeveloperIdProvider_GetLoginAdaptiveCardSession_NeverImplemented()
     {
         var developerIdProvider = DeveloperIdProvider.GetInstance(new MockAuthenticationHelper());
         Assert.IsNotNull(developerIdProvider);

--- a/test/AzureExtension/DeveloperId/DeveloperIdProviderTests.cs
+++ b/test/AzureExtension/DeveloperId/DeveloperIdProviderTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using AzureExtension.Test.DeveloperId.Mocks;
 using DevHomeAzureExtension.DeveloperId;
+using DevHomeAzureExtension.Test.DeveloperId.Mocks;
 using Microsoft.Windows.DevHome.SDK;
 
 namespace DevHomeAzureExtension.Test;
@@ -108,7 +108,7 @@ public partial class DeveloperIdTests
             var developerIdProvider = DeveloperIdProvider.GetInstance();
             Assert.IsNotNull(developerIdProvider);
 
-            var result = developerIdProvider.GetDeveloperIdState(new DeveloperId.DeveloperId());
+            var result = developerIdProvider.GetDeveloperIdState(new DevHomeAzureExtension.DeveloperId.DeveloperId());
             Assert.IsNotNull(result);
             Assert.AreEqual(AuthenticationState.LoggedOut, result);
         });
@@ -165,7 +165,7 @@ public partial class DeveloperIdTests
             var developerIdProvider = DeveloperIdProvider.GetInstance();
             Assert.IsNotNull(developerIdProvider);
 
-            var result = developerIdProvider.LogoutDeveloperId(new DeveloperId.DeveloperId());
+            var result = developerIdProvider.LogoutDeveloperId(new DevHomeAzureExtension.DeveloperId.DeveloperId());
             Assert.IsNotNull(result);
             Assert.AreEqual(ProviderOperationStatus.Failure, result.Status);
         });

--- a/test/AzureExtension/DeveloperId/DeveloperIdTests.cs
+++ b/test/AzureExtension/DeveloperId/DeveloperIdTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using DevHomeAzureExtension.DeveloperId;
+using Microsoft.UI;
 
 namespace DevHomeAzureExtension.Test;
 
@@ -18,8 +19,10 @@ public partial class DeveloperIdTests
         // Register for Login and Logout Events
         authProvider.Changed += AuthenticationEvent;
 
-        // Start a new login flow. Control flows to browser.
-        // Task.Run(async () => { await authProvider.LoginNewDeveloperIdAsync(); });
+        // Start a new interactive login flow
+        // var windowHandle = Application.Current.GetService<WindowEx>().GetWindowHandle();
+        // var windowPtr = Win32Interop.GetWindowIdFromWindow(windowHandle);
+        // Task.Run(async () => { await authProvider.ShowLogonSession(windowPtr); });
 
         // Get the list of DeveloperIds
         var devIds = authProvider.GetLoggedInDeveloperIdsInternal();

--- a/test/AzureExtension/DeveloperId/Mocks/MockAuthenticationHelper.cs
+++ b/test/AzureExtension/DeveloperId/Mocks/MockAuthenticationHelper.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DevHomeAzureExtension.DeveloperId;
+using Microsoft.Identity.Client;
+using Microsoft.UI;
+
+namespace AzureExtension.Test.DeveloperId.Mocks;
+
+internal class MockAuthenticationHelper : IAuthenticationHelper
+{
+    public AuthenticationSettings MicrosoftEntraIdSettings
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<string>> AcquireAllDeveloperAccountTokens(object scopesArray) => throw new NotImplementedException();
+
+    public Task<IEnumerable<string>> AcquireAllDeveloperAccountTokens(string[] scopes) => throw new NotImplementedException();
+
+    public Task<IAccount?> AcquireWindowsAccountTokenSilently(string[] scopes) => throw new NotImplementedException();
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+    public async Task<IEnumerable<string>> GetAllStoredLoginIdsAsync()
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+    {
+        var loginIds = new List<string>
+        {
+            "testAccount",
+            "testAccount2",
+            "testAccount3",
+        };
+
+        return loginIds;
+    }
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+    public async void InitializePublicClientAppForWAMBrokerAsync()
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+    {
+        return;
+    }
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+    public async Task InitializePublicClientAppForWAMBrokerAsyncWithParentWindow(WindowId? windowPtr)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+    {
+        return;
+    }
+
+    public void InitializePublicClientApplicationBuilder()
+    {
+    }
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+    public async Task<IAccount?> LoginDeveloperAccount(string[] scopes)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+    {
+       AuthenticationResult authResult = new AuthenticationResult(
+                accessToken: string.Empty,
+                isExtendedLifeTimeToken: false,
+                uniqueId: string.Empty,
+                expiresOn: DateTimeOffset.Now,
+                extendedExpiresOn: DateTimeOffset.Now,
+                tenantId: string.Empty,
+                account: null,
+                idToken: "id token",
+                scopes: new[] { "scope1", "scope2" },
+                correlationId: Guid.Empty,
+                authenticationResultMetadata: null,
+                tokenType: string.Empty);
+
+       return authResult.Account;
+    }
+
+    public Task<AuthenticationResult?> ObtainTokenForLoggedInDeveloperAccount(string[] scopesArray, string loginId) => throw new NotImplementedException();
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+    public async Task SignOutDeveloperIdAsync(string username)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+    {
+        return;
+    }
+}

--- a/test/AzureExtension/DeveloperId/Mocks/MockAuthenticationHelper.cs
+++ b/test/AzureExtension/DeveloperId/Mocks/MockAuthenticationHelper.cs
@@ -10,9 +10,8 @@ using DevHomeAzureExtension.DeveloperId;
 using Microsoft.Identity.Client;
 using Microsoft.UI;
 
-namespace AzureExtension.Test.DeveloperId.Mocks;
+namespace DevHomeAzureExtension.Test.DeveloperId.Mocks;
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 internal class MockAuthenticationHelper : IAuthenticationHelper
 {
     private readonly List<string> loginIds = new();
@@ -36,16 +35,19 @@ internal class MockAuthenticationHelper : IAuthenticationHelper
 
     public async Task<IEnumerable<string>> GetAllStoredLoginIdsAsync()
     {
+        await Task.Run(() => { });
         return loginIds;
     }
 
     public async void InitializePublicClientAppForWAMBrokerAsync()
     {
+        await Task.Run(() => { });
         return;
     }
 
     public async Task InitializePublicClientAppForWAMBrokerAsyncWithParentWindow(WindowId? windowPtr)
     {
+        await Task.Run(() => { });
         return;
     }
 
@@ -55,7 +57,8 @@ internal class MockAuthenticationHelper : IAuthenticationHelper
 
     public async Task<IAccount?> LoginDeveloperAccount(string[] scopes)
     {
-       AuthenticationResult authResult = new AuthenticationResult(
+        await Task.Run(() => { });
+        AuthenticationResult authResult = new AuthenticationResult(
                 accessToken: string.Empty,
                 isExtendedLifeTimeToken: false,
                 uniqueId: string.Empty,
@@ -69,14 +72,14 @@ internal class MockAuthenticationHelper : IAuthenticationHelper
                 authenticationResultMetadata: null,
                 tokenType: string.Empty);
 
-       return authResult.Account;
+        return authResult.Account;
     }
 
     public Task<AuthenticationResult?> ObtainTokenForLoggedInDeveloperAccount(string[] scopesArray, string loginId) => throw new NotImplementedException();
 
     public async Task SignOutDeveloperIdAsync(string username)
     {
+        await Task.Run(() => { });
         return;
     }
 }
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously

--- a/test/AzureExtension/DeveloperId/Mocks/MockAuthenticationHelper.cs
+++ b/test/AzureExtension/DeveloperId/Mocks/MockAuthenticationHelper.cs
@@ -12,8 +12,11 @@ using Microsoft.UI;
 
 namespace AzureExtension.Test.DeveloperId.Mocks;
 
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 internal class MockAuthenticationHelper : IAuthenticationHelper
 {
+    private readonly List<string> loginIds = new();
+
     public AuthenticationSettings MicrosoftEntraIdSettings
     {
         get => throw new NotImplementedException();
@@ -26,30 +29,22 @@ internal class MockAuthenticationHelper : IAuthenticationHelper
 
     public Task<IAccount?> AcquireWindowsAccountTokenSilently(string[] scopes) => throw new NotImplementedException();
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-    public async Task<IEnumerable<string>> GetAllStoredLoginIdsAsync()
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+    public void PopulateCache()
     {
-        var loginIds = new List<string>
-        {
-            "testAccount",
-            "testAccount2",
-            "testAccount3",
-        };
+        loginIds.Add("testAccount");
+    }
 
+    public async Task<IEnumerable<string>> GetAllStoredLoginIdsAsync()
+    {
         return loginIds;
     }
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
     public async void InitializePublicClientAppForWAMBrokerAsync()
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
     {
         return;
     }
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
     public async Task InitializePublicClientAppForWAMBrokerAsyncWithParentWindow(WindowId? windowPtr)
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
     {
         return;
     }
@@ -58,9 +53,7 @@ internal class MockAuthenticationHelper : IAuthenticationHelper
     {
     }
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
     public async Task<IAccount?> LoginDeveloperAccount(string[] scopes)
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
     {
        AuthenticationResult authResult = new AuthenticationResult(
                 accessToken: string.Empty,
@@ -81,10 +74,9 @@ internal class MockAuthenticationHelper : IAuthenticationHelper
 
     public Task<AuthenticationResult?> ObtainTokenForLoggedInDeveloperAccount(string[] scopesArray, string loginId) => throw new NotImplementedException();
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
     public async Task SignOutDeveloperIdAsync(string username)
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
     {
         return;
     }
 }
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously

--- a/test/AzureExtension/DeveloperId/Mocks/MockAuthenticationSettings.cs
+++ b/test/AzureExtension/DeveloperId/Mocks/MockAuthenticationSettings.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DevHomeAzureExtension.DeveloperId;
+
+namespace AzureExtension.Test.DeveloperId.Mocks;
+
+public class MockAuthenticationSettings : IAuthenticationSettings
+{
+    public void InitializeSettings()
+    {
+        // no settings to initalize for testing
+    }
+}


### PR DESCRIPTION
## Summary of the pull request
This PR adds unit tests for the DeveloperId feature in the DevHomeAzureExtension. 

## Detailed description of the pull request / Additional comments
This PR contains the below:
- Changes to use dependency injection to mock classes that call into MSAL APIs
- Unit tests for the DeveloperIdProvider interface

Future improvements will be made to better test the interactive login flow (i.e. confirm that clicking AddAccount opens the MSAL dialog on DevHome window etc.)

## Validation steps performed
Local Build
Manual testing of connecting developer account flow (login and logout)
Confirmed that the unit tests added here pass locally 

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
