### PR TITLE
Removing last tile from data string when remove action is invoked

### DIFF
--- a/src/AzureExtension/Widgets/AzureQueryTilesWidget.cs
+++ b/src/AzureExtension/Widgets/AzureQueryTilesWidget.cs
@@ -71,6 +71,16 @@ internal class AzureQueryTilesWidget : AzureWidget
         UpdateWidget();
     }
 
+    private string RemoveLastTileFromData(string data)
+    {
+        var dataObject = JsonObject.Parse(data)!.AsObject();
+
+        dataObject.Remove($"tileTitle{tiles.Count}");
+        dataObject.Remove($"query{tiles.Count}");
+
+        return dataObject.ToJsonString();
+    }
+
     protected void HandleRemoveTile(WidgetActionInvokedArgs args)
     {
         Page = WidgetPageState.Loading;
@@ -81,7 +91,7 @@ internal class AzureQueryTilesWidget : AzureWidget
             tiles.RemoveAt(tiles.Count - 1);
         }
 
-        UpdateAllTiles(args.Data);
+        UpdateAllTiles(RemoveLastTileFromData(args.Data));
         ValidateConfigurationData();
 
         Page = WidgetPageState.Configure;


### PR DESCRIPTION
## Summary of the pull request
This PR fixes a bug in the Azure Query Tiles widget where the `ConfigurationData` string was inconsistent with the actual state of the widget when the user clicks the remove tile button.
## References and relevant issues
#65 
## Detailed description of the pull request / Additional comments
### Before 
When the user clicks the "Remove tile" button, the data string the widget receives still contains information from the removed form. This resulted in a configuration being saved with a ghost tile if the remove action was the last one invoked before pinning or saving. 

This resulted in the widget showing this ghost tile whenever it needed to reload all the tiles from the `ConfigurationData` string, as this string is mirroring the data received from the forms. This happens when the widget service is restarted or when the user cancels a customization action.

### Currently
Now, invoking the remove widget action will remove the information from the last form from the data string accordingly, as this tile should not exist anymore. This way, the data will stay consistent with the intended behaviour of the widget, and will not have ghost tiles on the next restorations. 

## Validation steps performed

## PR checklist
- [ ] Closes #65
- [ ] Tests added/passed
- [ ] Documentation updated
