### PR TITLE
Improving customization experience on Azure Tiles Widget

### DIFF
--- a/src/AzureExtension/Widgets/Enums/WidgetAction.cs
+++ b/src/AzureExtension/Widgets/Enums/WidgetAction.cs
@@ -31,6 +31,21 @@ public enum WidgetAction
     RemoveTile,
 
     /// <summary>
+    /// Action to initiate the user Moved a tile up in the configuration.
+    /// </summary>
+    MoveTileUp,
+
+    /// <summary>
+    /// Action to initiate the user Moved a tile down in the configuration.
+    /// </summary>
+    MoveTileDown,
+
+    /// <summary>
+    /// Action to initiate the user Deleted a specific tile in the configuration.
+    /// </summary>
+    DeleteTile,
+
+    /// <summary>
     /// Action to save the updated configuration.
     /// </summary>
     Save,

--- a/src/AzureExtension/Widgets/Templates/AzureQueryTilesConfigurationTemplate.json
+++ b/src/AzureExtension/Widgets/Templates/AzureQueryTilesConfigurationTemplate.json
@@ -71,6 +71,38 @@
           "value": "${title}"
         },
         {
+          "type": "ActionSet",
+          "actions": [
+            {
+              "type": "Action.Execute",
+              "title": "^",
+              "id": "moveUp${$index}",
+              "verb": "MoveTileUp",
+              "data": {
+                "index": "${$index}"
+              }
+            },
+            {
+              "type": "Action.Execute",
+              "title": "v",
+              "id": "moveDown${$index}",
+              "verb": "MoveTileDown",
+              "data": {
+                "index": "${$index}"
+              }
+            },
+            {
+              "type": "Action.Execute",
+              "title": "x",
+              "id": "delete${$index}",
+              "verb": "DeleteTile",
+              "data": {
+                "index": "${$index}"
+              }
+            }
+          ]
+        },
+        {
           "type": "Container",
           "$when": "${message != null}",
           "items": [


### PR DESCRIPTION
## Summary of the pull request

**_This is an feature still in progress._**

This pull request improves the experience of customization in the Azure Tiles Widget adding the possibility to delete any tile, not only the last one; and also the possibility of moving a tile up and down in the order, making it easy to reordering them with not much changes.

## References and relevant issues

## Detailed description of the pull request / Additional comments

Three new actions were introduced: `MoveTileUp`, `MoveTileDown` and `DeleteTile`.

1. `MoveTileUp`: This action moves up a tile in the list, swapping it with the tile right before.
2. `MoveTileDown`: This action moves down a tile in the list, swapping it with the tile right afer.
3. `DeleteTile`:  This action deletes any tile when invoked, reorganizing the other tiles remaining in the list to fill its space.

For these new actions, each tile will have its own set of buttons in the customization page. _Design for this layout still in progress._ 
<img width="210" alt="image" src="https://github.com/microsoft/DevHomeAzureExtension/assets/13912953/6a85917b-f6ef-425a-a9df-0a7a16a63d39">


## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
