### PR TITLE
Update pin widget flow

### DIFF
--- a/src/AzureExtension/Widgets/AzureQueryTilesWidget.cs
+++ b/src/AzureExtension/Widgets/AzureQueryTilesWidget.cs
@@ -98,20 +98,6 @@ internal class AzureQueryTilesWidget : AzureWidget
         UpdateWidget();
     }
 
-    protected override void HandleSubmit(WidgetActionInvokedArgs args)
-    {
-        // This is the action when the user clicks the submit button after entering some data on the widget while in
-        // the Configure state.
-        Page = WidgetPageState.Loading;
-        UpdateWidget();
-
-        UpdateAllTiles(args.Data);
-        ValidateConfigurationData();
-
-        Page = WidgetPageState.Configure;
-        UpdateWidget();
-    }
-
     public override void OnActionInvoked(WidgetActionInvokedArgs actionInvokedArgs)
     {
         var verb = GetWidgetActionForVerb(actionInvokedArgs.Verb);
@@ -119,10 +105,6 @@ internal class AzureQueryTilesWidget : AzureWidget
 
         switch (verb)
         {
-            case WidgetAction.Submit:
-                HandleSubmit(actionInvokedArgs);
-                break;
-
             case WidgetAction.AddTile:
                 HandleAddTile(actionInvokedArgs);
                 break;
@@ -136,21 +118,25 @@ internal class AzureQueryTilesWidget : AzureWidget
                 break;
 
             case WidgetAction.Save:
-                SavedConfigurationData = string.Empty;
-                ContentData = EmptyJson;
-                SetActive();
+                if (ValidateConfiguration(actionInvokedArgs))
+                {
+                    SavedConfigurationData = string.Empty;
+                    ContentData = EmptyJson;
+                    DataState = WidgetDataState.Unknown;
+                    SetActive();
+                }
+
                 break;
 
             case WidgetAction.Cancel:
                 // Put back the configuration data from before we started changing the widget.
                 ConfigurationData = SavedConfigurationData;
                 SavedConfigurationData = string.Empty;
-                CanPin = true;
+                CanSave = true;
 
-                // Tiles were updated on Submit, restore them from the saved configuration data.
-                ResetNumberOfTilesFromData(ConfigurationData);
-                UpdateAllTiles(ConfigurationData);
-                ValidateConfigurationData();
+                // Tiles were updated on Save, restore them from the saved configuration data.
+                ResetDataFromState(ConfigurationData);
+
                 SetActive();
                 break;
 
@@ -160,10 +146,31 @@ internal class AzureQueryTilesWidget : AzureWidget
         }
     }
 
+    protected override bool ValidateConfiguration(WidgetActionInvokedArgs actionInvokedArgs)
+    {
+        Page = WidgetPageState.Loading;
+        UpdateWidget();
+
+        UpdateAllTiles(actionInvokedArgs.Data);
+        bool hasValidData = ValidateConfigurationData();
+        if (hasValidData)
+        {
+            Page = WidgetPageState.Content;
+            Pinned = true;
+        }
+        else
+        {
+            Page = WidgetPageState.Configure;
+        }
+
+        UpdateActivityState();
+        return hasValidData;
+    }
+
     public override void OnCustomizationRequested(WidgetCustomizationRequestedArgs customizationRequestedArgs)
     {
-        // Set CanPin to false so user will have to Submit again before Saving.
-        CanPin = false;
+        // Set CanSave to false so user will have to Submit again before Saving.
+        CanSave = false;
         SavedConfigurationData = ConfigurationData;
         SetConfigure();
     }
@@ -219,6 +226,13 @@ internal class AzureQueryTilesWidget : AzureWidget
 
         Log.Logger()?.ReportInfo(Name, ShortId, $"Requested data update for this widget.");
         DataState = WidgetDataState.Requested;
+    }
+
+    protected override void ResetDataFromState(string state)
+    {
+        ResetNumberOfTilesFromData(ConfigurationData);
+        UpdateAllTiles(ConfigurationData);
+        ValidateConfigurationData();
     }
 
     public override void LoadContentData()
@@ -287,21 +301,21 @@ internal class AzureQueryTilesWidget : AzureWidget
         UpdateActivityState();
     }
 
-    private void ValidateConfigurationData()
+    private bool ValidateConfigurationData()
     {
-        CanPin = false;
+        CanSave = false;
         var pinIssueFound = false;
 
         SetDefaultDeveloperLoginId();
         var developerId = GetDevId(DeveloperLoginId);
         if (developerId == null)
         {
-            return;
+            return false;
         }
 
         if (!tiles.Any())
         {
-            return;
+            return false;
         }
 
         for (var i = 0; i < tiles.Count; ++i)
@@ -333,10 +347,9 @@ internal class AzureQueryTilesWidget : AzureWidget
             tiles[i] = tile;
         }
 
-        if (!pinIssueFound)
-        {
-            CanPin = true;
-        }
+        CanSave = !pinIssueFound;
+
+        return !pinIssueFound;
     }
 
     private void ResetNumberOfTilesFromData(string data)
@@ -451,7 +464,6 @@ internal class AzureQueryTilesWidget : AzureWidget
 
         configurationData.Add("tiles", tilesArray);
         configurationData.Add("selectedDevId", DeveloperLoginId);
-        configurationData.Add("configuring", !CanPin);
         configurationData.Add("pinned", Pinned);
         configurationData.Add("arrow", IconLoader.GetIconAsBase64("arrow.png"));
 
@@ -478,7 +490,7 @@ internal class AzureQueryTilesWidget : AzureWidget
             WidgetPageState.SignIn => GetSignIn(),
             WidgetPageState.Configure => GetConfiguration(string.Empty),
             WidgetPageState.Content => ContentData,
-            WidgetPageState.Loading => new JsonObject { { "configuring", true } }.ToJsonString(),
+            WidgetPageState.Loading => EmptyJson,
             _ => throw new NotImplementedException(Page.GetType().Name),
         };
     }

--- a/src/AzureExtension/Widgets/Enums/WidgetAction.cs
+++ b/src/AzureExtension/Widgets/Enums/WidgetAction.cs
@@ -11,11 +11,6 @@ public enum WidgetAction
     Unknown,
 
     /// <summary>
-    /// Action to validate the URL provided by the user.
-    /// </summary>
-    Submit,
-
-    /// <summary>
     /// Action to initiate the user Sign-In.
     /// </summary>
     SignIn,

--- a/src/AzureExtension/Widgets/Enums/WidgetActivityState.cs
+++ b/src/AzureExtension/Widgets/Enums/WidgetActivityState.cs
@@ -11,8 +11,8 @@ public enum WidgetActivityState
     Unknown,
 
     /// <summary>
-    /// Widget is in this state after it is created before it has data assigned to it and before it
-    /// is pinned. Once data is assigned this state should never be reached.
+    /// Widget is in this state after it is created and before it has data assigned to it,
+    /// or when the Configure option has been selected.
     /// </summary>
     Configure,
 
@@ -22,7 +22,7 @@ public enum WidgetActivityState
     SignIn,
 
     /// <summary>
-    /// Widget is configured, pinned, and it is assumed user can interact and see it.
+    /// Widget is configured and it is assumed user can interact and see it.
     /// </summary>
     Active,
 

--- a/src/AzureExtension/Widgets/Templates/AzurePullRequestsConfigurationTemplate.json
+++ b/src/AzureExtension/Widgets/Templates/AzurePullRequestsConfigurationTemplate.json
@@ -27,12 +27,7 @@
           "label": "%Widget_Template/RepositoryURLLabel%",
           "style": "Url",
           "isRequired": true,
-          "errorMessage": "%Widget_Template_ErrorMessage/RepositoryURL%",
-          "inlineAction": {
-            "type": "Action.Execute",
-            "verb": "Submit",
-            "iconUrl": "data:image/png;base64,${arrow}"
-          }
+          "errorMessage": "%Widget_Template_ErrorMessage/RepositoryURL%"
         },
         {
           "type": "Input.ChoiceSet",
@@ -56,19 +51,6 @@
           "isRequired": true
         },
         {
-          "type": "ActionSet",
-          "actions": [
-            {
-              "type": "Action.Execute",
-              "title": "%Widget_Template_Button/Submit%",
-              "verb": "Submit",
-              "style": "positive",
-              "role": "Button",
-              "associatedInputs": "auto"
-            }
-          ]
-        },
-        {
           "type": "Container",
           "$when": "${message != null}",
           "items": [
@@ -84,7 +66,6 @@
         {
           "type": "ColumnSet",
           "spacing": "Medium",
-          "$when": "${$root.pinned}",
           "columns": [
             {
               "type": "Column",
@@ -104,16 +85,14 @@
                           "type": "Action.Execute",
                           "title": "%Widget_Template_Button/Save%",
                           "verb": "Save",
-                          "tooltip": "%Widget_Template_Tooltip/Save%",
-                          "style": "positive",
-                          "isEnabled": "${!$root.configuring}"
+                          "role": "Button",
+                          "associatedInputs": "auto"
                         },
                         {
                           "type": "Action.Execute",
                           "title": "%Widget_Template_Button/Cancel%",
                           "verb": "Cancel",
-                          "tooltip": "%Widget_Template_Tooltip/Cancel%",
-                          "style": "destructive"
+                          "isEnabled": "${$root.pinned}"
                         }
                       ]
                     }

--- a/src/AzureExtension/Widgets/Templates/AzureQueryListConfigurationTemplate.json
+++ b/src/AzureExtension/Widgets/Templates/AzureQueryListConfigurationTemplate.json
@@ -27,12 +27,7 @@
           "label": "%Widget_Template/QueryURLLabel%",
           "style": "Url",
           "isRequired": true,
-          "errorMessage": "%Widget_Template_ErrorMessage/QueryURL%",
-          "inlineAction": {
-            "type": "Action.Execute",
-            "verb": "Submit",
-            "iconUrl": "data:image/png;base64,${arrow}"
-          }
+          "errorMessage": "%Widget_Template_ErrorMessage/QueryURL%"
         },
         {
           "type": "Input.Text",
@@ -40,44 +35,6 @@
           "id": "widgetTitle",
           "label": "%Widget_Template/QueryTitleLabel%",
           "value": "${widgetTitle}"
-        },
-        {
-          "type": "ColumnSet",
-          "spacing": "Medium",
-          "columns": [
-            {
-              "type": "Column",
-              "width": "stretch"
-            },
-            {
-              "type": "Column",
-              "width": "auto",
-              "items": [
-                {
-                  "type": "Container",
-                  "items": [
-                    {
-                      "type": "ActionSet",
-                      "actions": [
-                        {
-                          "type": "Action.Execute",
-                          "title": "%Widget_Template_Button/Submit%",
-                          "verb": "Submit",
-                          "style": "positive",
-                          "role": "Button",
-                          "associatedInputs": "auto"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "Column",
-              "width": "stretch"
-            }
-          ]
         },
         {
           "type": "Container",
@@ -95,7 +52,6 @@
         {
           "type": "ColumnSet",
           "spacing": "Medium",
-          "$when": "${$root.pinned}",
           "columns": [
             {
               "type": "Column",
@@ -115,16 +71,14 @@
                           "type": "Action.Execute",
                           "title": "%Widget_Template_Button/Save%",
                           "verb": "Save",
-                          "tooltip": "%Widget_Template_Tooltip/Save%",
-                          "style": "positive",
-                          "isEnabled": "${!$root.configuring}"
+                          "role": "Button",
+                          "associatedInputs": "auto"
                         },
                         {
                           "type": "Action.Execute",
                           "title": "%Widget_Template_Button/Cancel%",
                           "verb": "Cancel",
-                          "tooltip": "%Widget_Template_Tooltip/Cancel%",
-                          "style": "destructive"
+                          "isEnabled": "${$root.pinned}"
                         }
                       ]
                     }

--- a/src/AzureExtension/Widgets/Templates/AzureQueryTilesConfigurationTemplate.json
+++ b/src/AzureExtension/Widgets/Templates/AzureQueryTilesConfigurationTemplate.json
@@ -56,12 +56,7 @@
           "id": "query${$index}",
           "label": "%Widget_Template/QueryURLLabel%",
           "style": "Url",
-          "value": "${url}",
-          "inlineAction": {
-            "type": "Action.Execute",
-            "verb": "Submit",
-            "iconUrl": "data:image/png;base64,${$root.arrow}"
-          }
+          "value": "${url}"
         },
         {
           "type": "Input.Text",
@@ -87,20 +82,6 @@
       "separator": true
     },
     {
-      "type": "Container",
-      "$when": "${!configuring}",
-      "items": [
-        {
-          "type": "TextBlock",
-          "text": "%Widget_Template/CanBePinned%",
-          "wrap": true,
-          "horizontalAlignment": "center"
-        }
-      ],
-      "style": "good",
-      "separator": true
-    },
-    {
       "type": "ColumnSet",
       "spacing": "Medium",
       "columns": [
@@ -119,14 +100,6 @@
                   "type": "ActionSet",
                   "separator": true,
                   "actions": [
-                    {
-                      "type": "Action.Execute",
-                      "title": "%Widget_Template_Button/Submit%",
-                      "verb": "Submit",
-                      "style": "positive",
-                      "role": "Button",
-                      "associatedInputs": "auto"
-                    },
                     {
                       "type": "Action.Execute",
                       "title": "%Widget_Template_Button/AddTile%",
@@ -160,7 +133,6 @@
     {
       "type": "ColumnSet",
       "spacing": "Medium",
-      "$when": "${$root.pinned}",
       "columns": [
         {
           "type": "Column",
@@ -180,16 +152,13 @@
                       "type": "Action.Execute",
                       "title": "%Widget_Template_Button/Save%",
                       "verb": "Save",
-                      "tooltip": "%Widget_Template_Tooltip/Save%",
-                      "style": "positive",
                       "isEnabled": "${!$root.configuring}"
                     },
                     {
                       "type": "Action.Execute",
                       "title": "%Widget_Template_Button/Cancel%",
                       "verb": "Cancel",
-                      "tooltip": "%Widget_Template_Tooltip/Cancel%",
-                      "style": "destructive"
+                      "isEnabled": "${$root.pinned}"
                     }
                   ]
                 }


### PR DESCRIPTION
## Summary of the pull request

Accommodate the updated pin widget flow from https://github.com/microsoft/devhome/pull/2110. Widgets are selected in the Add widget dialog and configured inline on the Dashboard, similar to how the Windows Widget Board does it.

## References and relevant issues

## Detailed description of the pull request / Additional comments

* This PR makes significant changes to the customization template, removing the arrow button and Submit button. Instead, input validation is done on Save.
* Since we don't have to communicate to the host that we're in configuration mode anymore, it is removed from the Data json.
* `CanPin` is renamed to CanSave, a more accurate name.
* `Pinned` indicates the state that the widget has ever had valid configuration data, and canceling customization will return the widget to that data.
* Save and Cancel buttons are no longer labeled "positive" and "destructive" to give them normal styling.
* Since there is no longer a different between "add" configuration state and "edit" configuration state, we can always show the Save and Cancel buttons in the Configuration template, although we only enable Cancel if there was once a valid state we can return to.

PR in Draft until we get screenshot assets.

![image](https://github.com/microsoft/DevHomeAzureExtension/assets/47155823/42f3bd81-2b91-4c04-837d-97f20c490a27)

## Validation steps performed

## PR checklist
- [ ] Closes #90
- [ ] Tests added/passed
- [ ] Documentation updated
