### PR TITLE
Fix signing in build script

### DIFF
--- a/build/scripts/Build.ps1
+++ b/build/scripts/Build.ps1
@@ -173,7 +173,7 @@ Try {
       .\build\scripts\Create-AppxBundle.ps1 -InputPath (Join-Path $env:Build_RootDirectory "AppxPackages\$configuration") -ProjectName AzureExtension -BundleVersion ([version]$env:msix_version) -OutputPath (Join-Path $env:Build_RootDirectory ("AppxBundles\$configuration\AzureExtension_" + $env:msix_version + "_8wekyb3d8bbwe.msixbundle"))
       if (-not($IsAzurePipelineBuild) -And $isAdmin) {
         # This can fail if SignTool.exe is not found, which is part of the Windows SDK.
-        Invoke-SignPackage ("AppxBundles\$configuration\DevHomeAzureExtension_" + $env:msix_version + "_8wekyb3d8bbwe.msixbundle")
+        Invoke-SignPackage ("AppxBundles\$configuration\AzureExtension_" + $env:msix_version + "_8wekyb3d8bbwe.msixbundle")
       }
     }
   }


### PR DESCRIPTION
## Summary of the pull request
Build script has wrong name when signing msixbundle

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
