### PR TITLE
[Dev][Deps] Update LibGit2Sharp to 0.29.0 to resolve cloning issues on Arm64

### DIFF
--- a/src/AzureExtension/AzureExtension.csproj
+++ b/src/AzureExtension/AzureExtension.csproj
@@ -49,7 +49,7 @@
   <ItemGroup>
       <PackageReference Include="Dapper" Version="2.0.123" />
       <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-      <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+      <PackageReference Include="LibGit2Sharp" Version="0.29.0" />
       <PackageReference Include="MessageFormat" Version="6.0.2" />
       <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.4" />
       <PackageReference Include="Microsoft.Identity.Client" Version="4.56.0" />

--- a/src/AzureExtension/Providers/RepositoryProvider.cs
+++ b/src/AzureExtension/Providers/RepositoryProvider.cs
@@ -347,7 +347,7 @@ public class RepositoryProvider : IRepositoryProvider
                     return new ProviderOperationResult(ProviderOperationStatus.Failure, e, $"Could not get the logged in developer.  HResult: {e.HResult}", e.Message);
                 }
 
-                cloneOptions.CredentialsProvider = (url, user, cred) => new LibGit2Sharp.UsernamePasswordCredentials
+                cloneOptions.FetchOptions.CredentialsProvider = (url, user, cred) => new LibGit2Sharp.UsernamePasswordCredentials
                 {
                     // Password is a PAT unique to GitHub.
                     Username = authResult.AccessToken,


### PR DESCRIPTION
## Summary of the pull request
Updates LibGit2Sharp to resolve repository cloning issues on Arm64
## References and relevant issues
#96 
## Detailed description of the pull request / Additional comments
The 0.26.2 version of LibGit2Sharp doesn't contain a native executable for Arm64 which causes cloning to fail. Updating to 0.29.0 results in a successful clone. 

## Validation steps performed
After making the changes needed, I ran the dev extension, turned off the store version of the extension, and went through the same process to clone a repository from Azure DevOps. 

Note: I had to restore the LibGit2Sharp using the NuGet.org package source since 0.29.0 isn't in the DevHomeDependencies source yet. 

Sucess! 
![image](https://github.com/microsoft/DevHomeAzureExtension/assets/4016293/8fc2beff-0a4d-437b-8720-d037ceeb67b1)
![image](https://github.com/microsoft/DevHomeAzureExtension/assets/4016293/f3cf1a24-bad8-43f4-bb56-c372c3f35c56)

## PR checklist
- [X] Closes #96
- [ ] Tests added/passed
- [ ] Documentation updated
