### PR TITLE
Add support for OneHop query type

### DIFF
--- a/src/AzureExtension/DataManager/AzureDataManager.cs
+++ b/src/AzureExtension/DataManager/AzureDataManager.cs
@@ -371,6 +371,11 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
 
                     break;
 
+                case TFModels.QueryType.OneHop:
+
+                    // OneHop work item structure is the same as the tree type.
+                    goto case TFModels.QueryType.Tree;
+
                 default:
                     Log.Logger()?.ReportWarn(Name, InstanceName, $"Found unhandled QueryType: {queryResult.QueryType} for query: {queryId}");
                     break;


### PR DESCRIPTION
## Summary of the pull request

Adds support for the OneHop QueryType. This is the "Work items and direct links" type of query if created in DevOps query editor.

## References and relevant issues
Closes #107 

## Detailed description of the pull request / Additional comments

Azure queries have three types, but only two were supported. The unsupported type, OneHop, is handled the same as a Tree type. This fix adds the case for OneHop and directs it to treat it as the Tree type for the purposes of extracting work item ids.

## Validation steps performed

Verified on a test OneHop query that fails on current version, but renders correctly with the fix.

## PR checklist
- [x] Closes #107
- [x] Tests added/passed
- [x] Documentation updated
