### PR TITLE
Correct file headers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,8 @@
 
 [*.cs]
 
+file_header_template = Copyright (c) Microsoft Corporation.\r\nLicensed under the MIT License.
+
 #Core editorconfig formatting - indentation
 
 #use soft tabs (spaces) for indentation

--- a/DevHomeAzureExtension.sln
+++ b/DevHomeAzureExtension.sln
@@ -45,6 +45,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{E4D6
 		test\scripts\CleanWidgets.ps1 = test\scripts\CleanWidgets.ps1
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D1A35C30-001C-4907-A6FD-E59F25D432CF}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/build/scripts/Build.ps1
+++ b/build/scripts/Build.ps1
@@ -12,7 +12,7 @@ $StartTime = Get-Date
 
 if ($Help) {
     Write-Host @"
-Copyright (c) Microsoft Corporation and Contributors.
+Copyright (c) Microsoft Corporation.
 Licensed under the MIT License.
 
 Syntax:

--- a/build/scripts/Test.ps1
+++ b/build/scripts/Test.ps1
@@ -9,7 +9,7 @@ $StartTime = Get-Date
 
 if ($Help) {
     Write-Host @"
-Copyright (c) Microsoft Corporation and Contributors.
+Copyright (c) Microsoft Corporation.
 Licensed under the MIT License.
 
 Syntax:

--- a/codeAnalysis/GlobalSuppressions.cs
+++ b/codeAnalysis/GlobalSuppressions.cs
@@ -13,10 +13,10 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1101:PrefixLocalCallsWithThis", Justification = "We follow the C# Core Coding Style which avoids using `this` unless absolutely necessary.")]
 
 [assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1200:UsingDirectivesMustBePlacedWithinNamespace", Justification = "We follow the C# Core Coding Style which puts using statements outside the namespace.")]
-[assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1201:ElementsMustAppearInTheCorrectOrder", Justification = "It is not a priority and have hight impact in code changes.")]
-[assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1202:ElementsMustBeOrderedByAccess", Justification = "It is not a priority and have hight impact in code changes.")]
-[assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1203:ConstantsMustAppearBeforeFields", Justification = "It is not a priority and have hight impact in code changes.")]
-[assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1204:StaticElementsMustAppearBeforeInstanceElements", Justification = "It is not a priority and have hight impact in code changes.")]
+[assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1201:ElementsMustAppearInTheCorrectOrder", Justification = "It is not a priority and has high impact in code changes.")]
+[assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1202:ElementsMustBeOrderedByAccess", Justification = "It is not a priority and has high impact in code changes.")]
+[assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1203:ConstantsMustAppearBeforeFields", Justification = "It is not a priority and has high impact in code changes.")]
+[assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1204:StaticElementsMustAppearBeforeInstanceElements", Justification = "It is not a priority and has high impact in code changes.")]
 
 [assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1309:FieldNamesMustNotBeginWithUnderscore", Justification = "We follow the C# Core Coding Style which uses underscores as prefixes rather than using `this.`.")]
 

--- a/codeAnalysis/GlobalSuppressions.cs
+++ b/codeAnalysis/GlobalSuppressions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 // This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.

--- a/codeAnalysis/StyleCop.json
+++ b/codeAnalysis/StyleCop.json
@@ -3,7 +3,7 @@
   "settings": {
     "documentationRules": {
       "companyName": "Microsoft Corporation",
-      "copyrightText": "Copyright (c) Microsoft Corporation and Contributors\r\nLicensed under the MIT license.",
+      "copyrightText": "Copyright (c) Microsoft Corporation.\r\nLicensed under the MIT License.",
       "xmlHeader": false,
       "headerDecoration": "",
       "fileNamingConvention": "metadata",

--- a/exclusion.dic
+++ b/exclusion.dic
@@ -12,3 +12,10 @@ brokerplugin
 Entra
 riid
 enums
+enums
+Stdout
+visualstudio
+vssps
+Entra
+riid
+foobar

--- a/src/AzureExtension/AzureExtension.cs
+++ b/src/AzureExtension/AzureExtension.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Runtime.InteropServices;
 using DevHomeAzureExtension.DeveloperId;

--- a/src/AzureExtension/Client/AzureClientHelpers.cs
+++ b/src/AzureExtension/Client/AzureClientHelpers.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.TeamFoundation.SourceControl.WebApi;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi;

--- a/src/AzureExtension/Client/AzureClientProvider.cs
+++ b/src/AzureExtension/Client/AzureClientProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Identity.Client;
 using Microsoft.VisualStudio.Services.Common;

--- a/src/AzureExtension/Client/AzureClientProvider.cs
+++ b/src/AzureExtension/Client/AzureClientProvider.cs
@@ -44,12 +44,12 @@ public class AzureClientProvider
             }
             catch (MsalServiceException ex)
             {
-                Log.Logger()?.ReportError($"Unable to get credentials for developerId: failed with msal service error: {ex}");
+                Log.Logger()?.ReportError($"Unable to get credentials for developerId: failed with MSAL service error: {ex}");
                 return null;
             }
             catch (MsalClientException ex)
             {
-                Log.Logger()?.ReportError($"Unable to get credentials for developerId: failed with msal client error: {ex}");
+                Log.Logger()?.ReportError($"Unable to get credentials for developerId: failed with MSAL client error: {ex}");
                 return null;
             }
             catch (Exception ex)
@@ -105,12 +105,12 @@ public class AzureClientProvider
         }
         catch (MsalServiceException ex)
         {
-            Log.Logger()?.ReportError($"AcquireDeveloperAccountToken failed with msal service error: {ex}");
+            Log.Logger()?.ReportError($"AcquireDeveloperAccountToken failed with MSAL service error: {ex}");
             return new ConnectionResult(ResultType.Failure, ErrorType.MsalServiceError, false, ex);
         }
         catch (MsalClientException ex)
         {
-            Log.Logger()?.ReportError($"AcquireDeveloperAccountToken failed with msal client error: {ex}");
+            Log.Logger()?.ReportError($"AcquireDeveloperAccountToken failed with MSAL client error: {ex}");
             return new ConnectionResult(ResultType.Failure, ErrorType.MsalClientError, false, ex);
         }
         catch (Exception ex)
@@ -143,9 +143,9 @@ public class AzureClientProvider
     }
 
     /// <summary>
-    /// Gets the azure devops connection for the specified developer id.
+    /// Gets the Azure DevOps connection for the specified developer id.
     /// </summary>
-    /// <param name="uri">The uri to an azure devops resource.</param>
+    /// <param name="uri">The uri to an Azure DevOps resource.</param>
     /// <param name="developerId">The developer to authenticate with.</param>
     /// <returns>An authorized connection to the resource.</returns>
     /// <exception cref="ArgumentException">If the azure uri is not valid.</exception>

--- a/src/AzureExtension/Client/AzureHostType.cs
+++ b/src/AzureExtension/Client/AzureHostType.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.Client;
 

--- a/src/AzureExtension/Client/AzureUri.cs
+++ b/src/AzureExtension/Client/AzureUri.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.Client;
 

--- a/src/AzureExtension/Client/ConnectionResult.cs
+++ b/src/AzureExtension/Client/ConnectionResult.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.VisualStudio.Services.WebApi;
 

--- a/src/AzureExtension/Client/ErrorType.cs
+++ b/src/AzureExtension/Client/ErrorType.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.Client;
 

--- a/src/AzureExtension/Client/InfoResult.cs
+++ b/src/AzureExtension/Client/InfoResult.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.Client;
 

--- a/src/AzureExtension/Client/InfoType.cs
+++ b/src/AzureExtension/Client/InfoType.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.Client;
 

--- a/src/AzureExtension/Client/Logging.cs
+++ b/src/AzureExtension/Client/Logging.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHome.Logging;
 using Windows.Storage;

--- a/src/AzureExtension/Client/ResultType.cs
+++ b/src/AzureExtension/Client/ResultType.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.Client;
 

--- a/src/AzureExtension/Configuration/DeveloperOAuthConfiguration.cs
+++ b/src/AzureExtension/Configuration/DeveloperOAuthConfiguration.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension;
 

--- a/src/AzureExtension/Configuration/OAuthConfiguration.cs
+++ b/src/AzureExtension/Configuration/OAuthConfiguration.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension;
 

--- a/src/AzureExtension/Constants.cs
+++ b/src/AzureExtension/Constants.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension;
 

--- a/src/AzureExtension/DataManager/AzureDataManager.cs
+++ b/src/AzureExtension/DataManager/AzureDataManager.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Concurrent;
 using System.Dynamic;

--- a/src/AzureExtension/DataManager/DataManagerUpdateEventArgs.cs
+++ b/src/AzureExtension/DataManager/DataManagerUpdateEventArgs.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.DataManager;
 

--- a/src/AzureExtension/DataManager/DataStoreOperationParameters.cs
+++ b/src/AzureExtension/DataManager/DataStoreOperationParameters.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHomeAzureExtension.Client;
 using DevHomeAzureExtension.DataModel;

--- a/src/AzureExtension/DataManager/DataUpdater.cs
+++ b/src/AzureExtension/DataManager/DataUpdater.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.DataManager;
 

--- a/src/AzureExtension/DataManager/IAzureDataManager.cs
+++ b/src/AzureExtension/DataManager/IAzureDataManager.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHomeAzureExtension.Client;
 using DevHomeAzureExtension.DataModel;

--- a/src/AzureExtension/DataManager/RequestOptions.cs
+++ b/src/AzureExtension/DataManager/RequestOptions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension;
 

--- a/src/AzureExtension/DataModel/AzureDataStoreSchema.cs
+++ b/src/AzureExtension/DataModel/AzureDataStoreSchema.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.DataModel;
 

--- a/src/AzureExtension/DataModel/DataObjects/Identity.cs
+++ b/src/AzureExtension/DataModel/DataObjects/Identity.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/AzureExtension/DataModel/DataObjects/MetaData.cs
+++ b/src/AzureExtension/DataModel/DataObjects/MetaData.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Dapper;
 using Dapper.Contrib.Extensions;

--- a/src/AzureExtension/DataModel/DataObjects/Organization.cs
+++ b/src/AzureExtension/DataModel/DataObjects/Organization.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Dapper;
 using Dapper.Contrib.Extensions;

--- a/src/AzureExtension/DataModel/DataObjects/Project.cs
+++ b/src/AzureExtension/DataModel/DataObjects/Project.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Dapper;
 using Dapper.Contrib.Extensions;

--- a/src/AzureExtension/DataModel/DataObjects/PullRequests.cs
+++ b/src/AzureExtension/DataModel/DataObjects/PullRequests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Dapper;
 using Dapper.Contrib.Extensions;

--- a/src/AzureExtension/DataModel/DataObjects/Query.cs
+++ b/src/AzureExtension/DataModel/DataObjects/Query.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Dapper;
 using Dapper.Contrib.Extensions;

--- a/src/AzureExtension/DataModel/DataObjects/WorkItemType.cs
+++ b/src/AzureExtension/DataModel/DataObjects/WorkItemType.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/AzureExtension/DataModel/DataStore.cs
+++ b/src/AzureExtension/DataModel/DataStore.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Globalization;
 using System.Reflection;

--- a/src/AzureExtension/DataModel/DataStoreOptions.cs
+++ b/src/AzureExtension/DataModel/DataStoreOptions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.DataModel;
 

--- a/src/AzureExtension/DataModel/DataStoreTransaction.cs
+++ b/src/AzureExtension/DataModel/DataStoreTransaction.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Data.Sqlite;
 

--- a/src/AzureExtension/DataModel/Enums/PullRequestView.cs
+++ b/src/AzureExtension/DataModel/Enums/PullRequestView.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.DataModel;
 

--- a/src/AzureExtension/DataModel/IDataStoreSchema.cs
+++ b/src/AzureExtension/DataModel/IDataStoreSchema.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.DataModel;
 

--- a/src/AzureExtension/DataModel/IDataStoreTransaction.cs
+++ b/src/AzureExtension/DataModel/IDataStoreTransaction.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.DataModel;
 

--- a/src/AzureExtension/DataModel/Logging.cs
+++ b/src/AzureExtension/DataModel/Logging.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHome.Logging;
 using Windows.Storage;

--- a/src/AzureExtension/DeveloperId/AuthenticationHelper.cs
+++ b/src/AzureExtension/DeveloperId/AuthenticationHelper.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Globalization;
 using Microsoft.Identity.Client;

--- a/src/AzureExtension/DeveloperId/AuthenticationHelper.cs
+++ b/src/AzureExtension/DeveloperId/AuthenticationHelper.cs
@@ -303,12 +303,12 @@ public class AuthenticationHelper : IAuthenticationHelper
             }
             catch (MsalServiceException ex)
             {
-                Log.Logger()?.ReportError($"AcquireDeveloperAccountToken failed with msal service error: {ex}");
+                Log.Logger()?.ReportError($"AcquireDeveloperAccountToken failed with MSAL service error: {ex}");
                 throw;
             }
             catch (MsalClientException ex)
             {
-                Log.Logger()?.ReportError($"AcquireDeveloperAccountToken failed with msal client error: {ex}");
+                Log.Logger()?.ReportError($"AcquireDeveloperAccountToken failed with MSAL client error: {ex}");
                 throw;
             }
             catch (Exception ex)

--- a/src/AzureExtension/DeveloperId/AuthenticationSettings.cs
+++ b/src/AzureExtension/DeveloperId/AuthenticationSettings.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Windows.Storage;
 

--- a/src/AzureExtension/DeveloperId/DeveloperId.cs
+++ b/src/AzureExtension/DeveloperId/DeveloperId.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Identity.Client;
 using Microsoft.VisualStudio.Services.Client;

--- a/src/AzureExtension/DeveloperId/DeveloperId.cs
+++ b/src/AzureExtension/DeveloperId/DeveloperId.cs
@@ -6,7 +6,6 @@ using Microsoft.VisualStudio.Services.Client;
 using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Services.WebApi;
 using Microsoft.Windows.DevHome.SDK;
-using Newtonsoft.Json.Linq;
 
 namespace DevHomeAzureExtension.DeveloperId;
 
@@ -65,12 +64,12 @@ public class DeveloperId : IDeveloperId
         }
         catch (MsalServiceException ex)
         {
-            Log.Logger()?.ReportError($"GetVssCredentials failed with msal service error: {ex}");
+            Log.Logger()?.ReportError($"GetVssCredentials failed with MSAL service error: {ex}");
             throw;
         }
         catch (MsalClientException ex)
         {
-            Log.Logger()?.ReportError($"GetVssCredentials failed with msal client error: {ex}");
+            Log.Logger()?.ReportError($"GetVssCredentials failed with MSAL client error: {ex}");
             throw;
         }
         catch (Exception ex)

--- a/src/AzureExtension/DeveloperId/DeveloperIdProvider.cs
+++ b/src/AzureExtension/DeveloperId/DeveloperIdProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Identity.Client;
 using Microsoft.UI;

--- a/src/AzureExtension/DeveloperId/DeveloperIdProvider.cs
+++ b/src/AzureExtension/DeveloperId/DeveloperIdProvider.cs
@@ -305,12 +305,12 @@ public class DeveloperIdProvider : IDeveloperIdProvider
         }
         catch (MsalServiceException ex)
         {
-            Log.Logger()?.ReportError($"AcquireDeveloperAccountToken failed with msal service error: {ex}");
+            Log.Logger()?.ReportError($"AcquireDeveloperAccountToken failed with MSAL service error: {ex}");
             throw;
         }
         catch (MsalClientException ex)
         {
-            Log.Logger()?.ReportError($"AcquireDeveloperAccountToken failed with msal client error: {ex}");
+            Log.Logger()?.ReportError($"AcquireDeveloperAccountToken failed with MSAL client error: {ex}");
             throw;
         }
         catch (Exception ex)

--- a/src/AzureExtension/DeveloperId/IAuthenticationHelper.cs
+++ b/src/AzureExtension/DeveloperId/IAuthenticationHelper.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Identity.Client;
 using Microsoft.UI;

--- a/src/AzureExtension/DeveloperId/IAuthenticationHelper.cs
+++ b/src/AzureExtension/DeveloperId/IAuthenticationHelper.cs
@@ -3,8 +3,6 @@
 
 using Microsoft.Identity.Client;
 using Microsoft.UI;
-using Microsoft.Windows.DevHome.SDK;
-using Windows.Foundation;
 
 namespace DevHomeAzureExtension.DeveloperId;
 

--- a/src/AzureExtension/DeveloperId/IAuthenticationSettings.cs
+++ b/src/AzureExtension/DeveloperId/IAuthenticationSettings.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.DeveloperId;
 

--- a/src/AzureExtension/DeveloperId/Logging.cs
+++ b/src/AzureExtension/DeveloperId/Logging.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHome.Logging;
 using Windows.Storage;

--- a/src/AzureExtension/DeveloperId/MSALLogger.cs
+++ b/src/AzureExtension/DeveloperId/MSALLogger.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.IdentityModel.Abstractions;
 

--- a/src/AzureExtension/Exceptions/AzureAuthorizationException.cs
+++ b/src/AzureExtension/Exceptions/AzureAuthorizationException.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension;
 

--- a/src/AzureExtension/Exceptions/AzureClientException.cs
+++ b/src/AzureExtension/Exceptions/AzureClientException.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension;
 

--- a/src/AzureExtension/Exceptions/DataStoreException.cs
+++ b/src/AzureExtension/Exceptions/DataStoreException.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension;
 

--- a/src/AzureExtension/Exceptions/DataStoreInaccessibleException.cs
+++ b/src/AzureExtension/Exceptions/DataStoreInaccessibleException.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension;
 

--- a/src/AzureExtension/Exceptions/InvalidApiException.cs
+++ b/src/AzureExtension/Exceptions/InvalidApiException.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension;
 

--- a/src/AzureExtension/Exceptions/RepositoryNotFoundException.cs
+++ b/src/AzureExtension/Exceptions/RepositoryNotFoundException.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension;
 

--- a/src/AzureExtension/Helpers/DateTimeExtensions.cs
+++ b/src/AzureExtension/Helpers/DateTimeExtensions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Globalization;
 

--- a/src/AzureExtension/Helpers/IconLoader.cs
+++ b/src/AzureExtension/Helpers/IconLoader.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHomeAzureExtension.DataModel;
 

--- a/src/AzureExtension/Helpers/Links.cs
+++ b/src/AzureExtension/Helpers/Links.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.VisualStudio.Services.WebApi;
 

--- a/src/AzureExtension/Helpers/Resources.cs
+++ b/src/AzureExtension/Helpers/Resources.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHome.Logging;
 using Microsoft.Windows.ApplicationModel.Resources;

--- a/src/AzureExtension/Helpers/StringExtensions.cs
+++ b/src/AzureExtension/Helpers/StringExtensions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Globalization;
 

--- a/src/AzureExtension/Helpers/TimeSpanHelper.cs
+++ b/src/AzureExtension/Helpers/TimeSpanHelper.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHome.Logging;
 using Jeffijoe.MessageFormat;

--- a/src/AzureExtension/Notifications/Logging.cs
+++ b/src/AzureExtension/Notifications/Logging.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHome.Logging;
 using Windows.Storage;

--- a/src/AzureExtension/Notifications/NotificationHandler.cs
+++ b/src/AzureExtension/Notifications/NotificationHandler.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Diagnostics;
 using System.Globalization;

--- a/src/AzureExtension/Notifications/NotificationManager.cs
+++ b/src/AzureExtension/Notifications/NotificationManager.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Windows.AppNotifications;
 

--- a/src/AzureExtension/Providers/DevHomeRepository.cs
+++ b/src/AzureExtension/Providers/DevHomeRepository.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHomeAzureExtension.Client;
 using Microsoft.TeamFoundation.SourceControl.WebApi;

--- a/src/AzureExtension/Providers/Logging.cs
+++ b/src/AzureExtension/Providers/Logging.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHome.Logging;
 using Windows.Storage;

--- a/src/AzureExtension/Providers/RepositoryProvider.cs
+++ b/src/AzureExtension/Providers/RepositoryProvider.cs
@@ -49,7 +49,7 @@ public class RepositoryProvider : IRepositoryProvider
             var azureUri = new AzureUri(uri);
             if (!azureUri.IsValid)
             {
-                return new RepositoryUriSupportResult(new ArgumentException("Not a valid Azure DevOps Uri"), "Uri isn not valid");
+                return new RepositoryUriSupportResult(new ArgumentException("Not a valid Azure DevOps Uri"), "Uri is not valid");
             }
 
             if (!azureUri.IsRepository)

--- a/src/AzureExtension/Providers/RepositoryProvider.cs
+++ b/src/AzureExtension/Providers/RepositoryProvider.cs
@@ -49,7 +49,7 @@ public class RepositoryProvider : IRepositoryProvider
             var azureUri = new AzureUri(uri);
             if (!azureUri.IsValid)
             {
-                return new RepositoryUriSupportResult(new ArgumentException("Not a valid Azure Devops Uri"), "Uri isn not valid");
+                return new RepositoryUriSupportResult(new ArgumentException("Not a valid Azure DevOps Uri"), "Uri isn not valid");
             }
 
             if (!azureUri.IsRepository)
@@ -258,7 +258,7 @@ public class RepositoryProvider : IRepositoryProvider
                 var repoInformation = new AzureUri(uri);
                 if (!repoInformation.IsValid)
                 {
-                    var exception = new NotSupportedException("Uri isn't a valid Azure Devops uri.");
+                    var exception = new NotSupportedException("Uri isn't a valid Azure DevOps uri.");
                     return new RepositoryResult(exception, $"{exception.Message} HResult: {exception.HResult}");
                 }
 

--- a/src/AzureExtension/Providers/RepositoryProvider.cs
+++ b/src/AzureExtension/Providers/RepositoryProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Security.Authentication;
 using System.Text;

--- a/src/AzureExtension/Widgets/AzurePullRequestsWidget.cs
+++ b/src/AzureExtension/Widgets/AzurePullRequestsWidget.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Text.Json.Nodes;
 using DevHomeAzureExtension.Client;

--- a/src/AzureExtension/Widgets/AzureQueryListWidget.cs
+++ b/src/AzureExtension/Widgets/AzureQueryListWidget.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Text.Json.Nodes;
 using DevHomeAzureExtension.Client;

--- a/src/AzureExtension/Widgets/AzureQueryTilesWidget.cs
+++ b/src/AzureExtension/Widgets/AzureQueryTilesWidget.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Text.Json.Nodes;
 using DevHomeAzureExtension.Client;

--- a/src/AzureExtension/Widgets/AzureWidget.cs
+++ b/src/AzureExtension/Widgets/AzureWidget.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Text;
 using System.Text.Json.Nodes;

--- a/src/AzureExtension/Widgets/Enums/WidgetAction.cs
+++ b/src/AzureExtension/Widgets/Enums/WidgetAction.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.Widgets.Enums;
 

--- a/src/AzureExtension/Widgets/Enums/WidgetActivityState.cs
+++ b/src/AzureExtension/Widgets/Enums/WidgetActivityState.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.Widgets.Enums;
 

--- a/src/AzureExtension/Widgets/Enums/WidgetDataState.cs
+++ b/src/AzureExtension/Widgets/Enums/WidgetDataState.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.Widgets;
 

--- a/src/AzureExtension/Widgets/Enums/WidgetPageState.cs
+++ b/src/AzureExtension/Widgets/Enums/WidgetPageState.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.Widgets;
 

--- a/src/AzureExtension/Widgets/Guids.cs
+++ b/src/AzureExtension/Widgets/Guids.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Runtime.InteropServices;
 

--- a/src/AzureExtension/Widgets/IWidgetImplFactory.cs
+++ b/src/AzureExtension/Widgets/IWidgetImplFactory.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Windows.Widgets.Providers;
 

--- a/src/AzureExtension/Widgets/Logging.cs
+++ b/src/AzureExtension/Widgets/Logging.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHome.Logging;
 using Windows.Storage;

--- a/src/AzureExtension/Widgets/WidgetImpl.cs
+++ b/src/AzureExtension/Widgets/WidgetImpl.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHomeAzureExtension.Telemetry;
 using Microsoft.Windows.Widgets.Providers;

--- a/src/AzureExtension/Widgets/WidgetImplFactory.cs
+++ b/src/AzureExtension/Widgets/WidgetImplFactory.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Windows.Widgets.Providers;
 

--- a/src/AzureExtension/Widgets/WidgetProvider.cs
+++ b/src/AzureExtension/Widgets/WidgetProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Runtime.InteropServices;
 using Microsoft.Windows.Widgets.Providers;

--- a/src/AzureExtension/Widgets/WidgetProviderFactory.cs
+++ b/src/AzureExtension/Widgets/WidgetProviderFactory.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Runtime.InteropServices;
 using DevHomeAzureExtension.Widgets.COM;

--- a/src/AzureExtension/Widgets/WidgetServer.cs
+++ b/src/AzureExtension/Widgets/WidgetServer.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;

--- a/src/AzureExtensionServer/Logging.cs
+++ b/src/AzureExtensionServer/Logging.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHome.Logging;
 using Windows.Storage;

--- a/src/AzureExtensionServer/Program.cs
+++ b/src/AzureExtensionServer/Program.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHomeAzureExtension.DataModel;
 using DevHomeAzureExtension.DeveloperId;

--- a/src/Logging/helpers/DictionaryExtensions.cs
+++ b/src/Logging/helpers/DictionaryExtensions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHome.Logging.Helpers;
 

--- a/src/Logging/helpers/FileSystem.cs
+++ b/src/Logging/helpers/FileSystem.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHome.Logging.Helpers;
 

--- a/src/Logging/helpers/StringExtensions.cs
+++ b/src/Logging/helpers/StringExtensions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Globalization;
 

--- a/src/Logging/listeners/DebugListener.cs
+++ b/src/Logging/listeners/DebugListener.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Diagnostics;
 using System.Globalization;

--- a/src/Logging/listeners/DebugListenerOptions.cs
+++ b/src/Logging/listeners/DebugListenerOptions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHome.Logging;
 

--- a/src/Logging/listeners/IListener.cs
+++ b/src/Logging/listeners/IListener.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHome.Logging.Listeners;
 

--- a/src/Logging/listeners/ListenerBase.cs
+++ b/src/Logging/listeners/ListenerBase.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using DevHome.Logging;
-
 namespace DevHome.Logging.Listeners;
 
 public abstract class ListenerBase : IListener

--- a/src/Logging/listeners/ListenerBase.cs
+++ b/src/Logging/listeners/ListenerBase.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHome.Logging;
 

--- a/src/Logging/listeners/LogFileListener.cs
+++ b/src/Logging/listeners/LogFileListener.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Globalization;
 

--- a/src/Logging/listeners/LogFileListenerOptions.cs
+++ b/src/Logging/listeners/LogFileListenerOptions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHome.Logging;
 

--- a/src/Logging/listeners/StdoutListener.cs
+++ b/src/Logging/listeners/StdoutListener.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Globalization;
 

--- a/src/Logging/listeners/StdoutListenerOptions.cs
+++ b/src/Logging/listeners/StdoutListenerOptions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHome.Logging;
 

--- a/src/Logging/logger/ILoggerHost.cs
+++ b/src/Logging/logger/ILoggerHost.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHome.Logging.Listeners;
 

--- a/src/Logging/logger/LogEvent.cs
+++ b/src/Logging/logger/LogEvent.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHome.Logging.Helpers;
 

--- a/src/Logging/logger/Logger.cs
+++ b/src/Logging/logger/Logger.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Concurrent;
 using DevHome.Logging.Helpers;

--- a/src/Logging/logger/Options.cs
+++ b/src/Logging/logger/Options.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHome.Logging;
 

--- a/src/Logging/logger/SeverityLevel.cs
+++ b/src/Logging/logger/SeverityLevel.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHome.Logging;
 

--- a/src/Telemetry/ILogger.cs
+++ b/src/Telemetry/ILogger.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Telemetry/LogLevel.cs
+++ b/src/Telemetry/LogLevel.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/Telemetry/LogLevel.cs
+++ b/src/Telemetry/LogLevel.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace DevHomeAzureExtension.Telemetry;
 
 /// <summary>

--- a/src/Telemetry/Logger.cs
+++ b/src/Telemetry/Logger.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/Telemetry/LoggerFactory.cs
+++ b/src/Telemetry/LoggerFactory.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.Telemetry;
 

--- a/test/AzureExtension/DataStore/DataManagerTests.cs
+++ b/test/AzureExtension/DataStore/DataManagerTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.VisualStudio.Services.WebApi;
-
 namespace DevHomeAzureExtension.Test;
 
 public partial class DataStoreTests
@@ -78,7 +76,7 @@ public partial class DataStoreTests
     [TestCategory("Unit")]
     public void DataManagerGetAndUpdateQuery()
     {
-        // In absence of public data and a private devops server, this test will just verify
+        // In absence of public data and a private DevOps server, this test will just verify
         // accessibility of the methods.
         using var log = new DevHome.Logging.Logger("TestStore", TestOptions.LogOptions);
         var testListener = new TestListener("TestListener", TestContext!);
@@ -88,7 +86,7 @@ public partial class DataStoreTests
         using var dataManager = AzureDataManager.CreateInstance("Test", TestOptions.DataStoreOptions);
         Assert.IsNotNull(dataManager);
 
-        // Skipping the request test here becuase this test runs unpackaged and
+        // Skipping the request test here because this test runs unpackaged and
         // AuthenticationSettings does not work correctly in this scenario in setting the MSIL
         // cache location.
         var query = dataManager.GetQuery("NotARealQuery", "SomeDevId");

--- a/test/AzureExtension/DataStore/DataManagerTests.cs
+++ b/test/AzureExtension/DataStore/DataManagerTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.VisualStudio.Services.WebApi;
 

--- a/test/AzureExtension/DataStore/DataObjectTests.cs
+++ b/test/AzureExtension/DataStore/DataObjectTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Text.Json.Nodes;
 using Dapper.Contrib.Extensions;
 using DevHome.Logging;
 using DevHomeAzureExtension.DataModel;

--- a/test/AzureExtension/DataStore/DataObjectTests.cs
+++ b/test/AzureExtension/DataStore/DataObjectTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Text.Json.Nodes;
 using Dapper.Contrib.Extensions;

--- a/test/AzureExtension/DataStore/DataStoreTestsSetup.cs
+++ b/test/AzureExtension/DataStore/DataStoreTestsSetup.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.Test;
 

--- a/test/AzureExtension/DeveloperId/DeveloperIdProviderTests.cs
+++ b/test/AzureExtension/DeveloperId/DeveloperIdProviderTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHomeAzureExtension.DeveloperId;
 using DevHomeAzureExtension.Test.DeveloperId.Mocks;

--- a/test/AzureExtension/DeveloperId/DeveloperIdTests.cs
+++ b/test/AzureExtension/DeveloperId/DeveloperIdTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHomeAzureExtension.DeveloperId;
 using Microsoft.UI;

--- a/test/AzureExtension/DeveloperId/DeveloperIdTests.cs
+++ b/test/AzureExtension/DeveloperId/DeveloperIdTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using DevHomeAzureExtension.DeveloperId;
-using Microsoft.UI;
 
 namespace DevHomeAzureExtension.Test;
 

--- a/test/AzureExtension/DeveloperId/DeveloperIdTestsSetup.cs
+++ b/test/AzureExtension/DeveloperId/DeveloperIdTestsSetup.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Windows.DevHome.SDK;
 

--- a/test/AzureExtension/DeveloperId/Mocks/MockAuthenticationHelper.cs
+++ b/test/AzureExtension/DeveloperId/Mocks/MockAuthenticationHelper.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/test/AzureExtension/DeveloperId/Mocks/MockAuthenticationHelper.cs
+++ b/test/AzureExtension/DeveloperId/Mocks/MockAuthenticationHelper.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using DevHomeAzureExtension.DeveloperId;
 using Microsoft.Identity.Client;
 using Microsoft.UI;

--- a/test/AzureExtension/DeveloperId/Mocks/MockAuthenticationSettings.cs
+++ b/test/AzureExtension/DeveloperId/Mocks/MockAuthenticationSettings.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/test/AzureExtension/DeveloperId/Mocks/MockAuthenticationSettings.cs
+++ b/test/AzureExtension/DeveloperId/Mocks/MockAuthenticationSettings.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using DevHomeAzureExtension.DeveloperId;
 
 namespace AzureExtension.Test.DeveloperId.Mocks;
@@ -14,6 +9,6 @@ public class MockAuthenticationSettings : IAuthenticationSettings
 {
     public void InitializeSettings()
     {
-        // no settings to initalize for testing
+        // no settings to initialize for testing
     }
 }

--- a/test/AzureExtension/Helpers/FileHelpers.cs
+++ b/test/AzureExtension/Helpers/FileHelpers.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.Test;
 

--- a/test/AzureExtension/Helpers/TestOptions.cs
+++ b/test/AzureExtension/Helpers/TestOptions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHome.Logging;
 using DevHomeAzureExtension.DataModel;

--- a/test/AzureExtension/Helpers/TestSetupHelpers.cs
+++ b/test/AzureExtension/Helpers/TestSetupHelpers.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using DevHome.Logging;
 using DevHome.Logging.Helpers;

--- a/test/AzureExtension/Helpers/TestSetupHelpers.cs
+++ b/test/AzureExtension/Helpers/TestSetupHelpers.cs
@@ -36,7 +36,7 @@ public partial class TestHelpers
         }
         catch (IOException)
         {
-            // Log writing being asychronous can sometimes lead to a test finishing before its
+            // Log writing being asynchronous can sometimes lead to a test finishing before its
             // log is done writing. This was leading to random intermittent test failures due
             // to the log file being in use. If we encounter an IOException, wait a few seconds
             // and try again.

--- a/test/AzureExtension/Initialize.cs
+++ b/test/AzureExtension/Initialize.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Windows.ApplicationModel.DynamicDependency;
 

--- a/test/AzureExtension/RepositoryProvider/Mocks/MockRepository.cs
+++ b/test/AzureExtension/RepositoryProvider/Mocks/MockRepository.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Windows.DevHome.SDK;
 using Windows.Foundation;

--- a/test/AzureExtension/RepositoryProvider/RepositoryProviderTests.cs
+++ b/test/AzureExtension/RepositoryProvider/RepositoryProviderTests.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Runtime.CompilerServices;
 using DevHomeAzureExtension.Client;
 using Microsoft.Windows.DevHome.SDK;
-using static DevHomeAzureExtension.Test.WidgetTests;
 
 namespace DevHomeAzureExtension.Test;
 

--- a/test/AzureExtension/RepositoryProvider/RepositoryProviderTests.cs
+++ b/test/AzureExtension/RepositoryProvider/RepositoryProviderTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Runtime.CompilerServices;
 using DevHomeAzureExtension.Client;

--- a/test/AzureExtension/RepositoryProvider/RepositoryProviderTestsSetup.cs
+++ b/test/AzureExtension/RepositoryProvider/RepositoryProviderTestsSetup.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.Test;
 

--- a/test/AzureExtension/TestListener.cs
+++ b/test/AzureExtension/TestListener.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Globalization;
 using DevHome.Logging;

--- a/test/AzureExtension/Usings.cs
+++ b/test/AzureExtension/Usings.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 global using Microsoft.VisualStudio.TestTools.UnitTesting;
 global using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;

--- a/test/AzureExtension/Widgets/Icons.cs
+++ b/test/AzureExtension/Widgets/Icons.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using DevHome.Logging;
 
 namespace DevHomeAzureExtension.Test;

--- a/test/AzureExtension/Widgets/Validation.cs
+++ b/test/AzureExtension/Widgets/Validation.cs
@@ -140,7 +140,7 @@ public partial class WidgetTests
             Tuple.Create("https://vssps.dev.azure.com:443/organization/with/extra/stuff", AzureUriType.SignIn, false),
             Tuple.Create("https://vssps.dev.azure.com:443/organization/with/extra/stuff/", AzureUriType.SignIn, false),
 
-            // Azure Devops SignIn Uris, legacy format.
+            // Azure DevOps SignIn Uris, legacy format.
             // Note port 443 is the default port for https, so Uri objects remove it.
             Tuple.Create("https://app.vssps.visualstudio.com/", AzureUriType.SignIn, false),
             Tuple.Create("https://app.vssps.visualstudio.com:443/", AzureUriType.SignIn, false),
@@ -194,9 +194,9 @@ public partial class WidgetTests
 
             if (uriTuple.Item2 != AzureUriType.SignIn && uriTuple.Item2 != AzureUriType.RepositoryNoProject && uriTuple.Item2 != AzureUriType.NamesWithSpaces)
             {
-                // Signin Uris may not have project.
+                // SignIn Uris may not have project.
                 // Some repository URIs will have a different project.
-                // Signin Uris can also have "app" as the organization.
+                // SignIn Uris can also have "app" as the organization.
                 // Organization will be validated as part of that type.
                 Assert.AreEqual("organization", azureUri.Organization);
                 Assert.AreEqual("project", azureUri.Project);
@@ -361,8 +361,8 @@ public partial class WidgetTests
         }
 
         // Null string input validation
-        string? nullstr = null;
-        var nullTest = new AzureUri(nullstr);
+        string? nullStr = null;
+        var nullTest = new AzureUri(nullStr);
         Assert.IsNotNull(nullTest);
         Assert.AreEqual(string.Empty, nullTest.ToString());
         Assert.IsFalse(nullTest.IsValid);
@@ -374,8 +374,8 @@ public partial class WidgetTests
         Assert.IsFalse(nullTest.IsValid);
 
         // Null Uri input validation
-        Uri? nulluri = null;
-        nullTest = new AzureUri(nulluri);
+        Uri? nullUri = null;
+        nullTest = new AzureUri(nullUri);
         Assert.IsNotNull(nullTest);
         Assert.AreEqual(string.Empty, nullTest.ToString());
         Assert.IsFalse(nullTest.IsValid);

--- a/test/AzureExtension/Widgets/Validation.cs
+++ b/test/AzureExtension/Widgets/Validation.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using DevHome.Logging;
 using DevHomeAzureExtension.Client;
 

--- a/test/AzureExtension/Widgets/WidgetTestsSetup.cs
+++ b/test/AzureExtension/Widgets/WidgetTestsSetup.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace DevHomeAzureExtension.Test;
 

--- a/test/Console/Program.cs
+++ b/test/Console/Program.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 internal class Program
 {


### PR DESCRIPTION
## Summary of the pull request
Correcting copyright headers to align with Microsoft open source process.
Add file_header_template in .editorconfig and fix copyrightText in stylecop.json.
Fixed some spelling mistakes I saw along the way and removed unused "using"s.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
