### PR TITLE
Add Avatar caching and display

### DIFF
--- a/src/AzureExtension/DataManager/AzureDataManager.cs
+++ b/src/AzureExtension/DataManager/AzureDataManager.cs
@@ -432,7 +432,7 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
 
                     if (fieldValue == "Microsoft.VisualStudio.Services.WebApi.IdentityRef")
                     {
-                        var identity = Identity.GetOrCreateIdentity(DataStore, workItem.Fields[field] as IdentityRef);
+                        var identity = Identity.GetOrCreateIdentity(DataStore, workItem.Fields[field] as IdentityRef, result.Connection);
                         workItemObjFields.Add(field, identity);
                         continue;
                     }
@@ -575,7 +575,7 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
                 pullRequestObjFields.Add("Id", pullRequest.PullRequestId);
                 pullRequestObjFields.Add("Title", pullRequest.Title);
 
-                var creator = Identity.GetOrCreateIdentity(DataStore, pullRequest.CreatedBy);
+                var creator = Identity.GetOrCreateIdentity(DataStore, pullRequest.CreatedBy, result.Connection);
                 pullRequestObjFields.Add("CreatedBy", creator);
                 pullRequestObjFields.Add("CreationDate", pullRequest.CreationDate.Ticks);
                 pullRequestObjFields.Add("TargetBranch", pullRequest.TargetRefName);

--- a/src/AzureExtension/DataManager/AzureDataManager.cs
+++ b/src/AzureExtension/DataManager/AzureDataManager.cs
@@ -28,7 +28,13 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
 
     public static readonly string RecreateDataStoreSettingsKey = "RecreateDataStore";
 
+    public static readonly string IdentityRefFieldValueName = "Microsoft.VisualStudio.Services.WebApi.IdentityRef";
+
+    public static readonly string SystemIdFieldName = "System.Id";
+
     public static readonly string WorkItemHtmlUrlFieldName = "DevHome.AzureExtension.WorkItemHtmlUrl";
+
+    public static readonly string WorkItemTypeFieldName = "System.WorkItemType";
 
     // Max number pull requests to fetch for a repository search.
     public static readonly int PullRequestResultLimit = 25;
@@ -395,7 +401,7 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
                 var workItemObjFields = (IDictionary<string, object>)workItemObj;
 
                 // System.Id is excluded from the query result.
-                workItemObjFields.Add("System.Id", workItem.Id!);
+                workItemObjFields.Add(SystemIdFieldName, workItem.Id!);
 
                 var htmlUrl = Links.GetLinkHref(workItem.Links, "html");
                 workItemObjFields.Add(WorkItemHtmlUrlFieldName, htmlUrl);
@@ -430,14 +436,14 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
                         continue;
                     }
 
-                    if (fieldValue == "Microsoft.VisualStudio.Services.WebApi.IdentityRef")
+                    if (fieldValue == IdentityRefFieldValueName)
                     {
                         var identity = Identity.GetOrCreateIdentity(DataStore, workItem.Fields[field] as IdentityRef, result.Connection);
                         workItemObjFields.Add(field, identity);
                         continue;
                     }
 
-                    if (field == "System.WorkItemType")
+                    if (field == WorkItemTypeFieldName)
                     {
                         var workItemType = WorkItemType.Get(DataStore, fieldValue, project.Id);
                         if (workItemType == null)

--- a/src/AzureExtension/DataModel/DataObjects/Identity.cs
+++ b/src/AzureExtension/DataModel/DataObjects/Identity.cs
@@ -173,7 +173,7 @@ public class Identity
         // Check for whether we need to update the record.
         // We don't want to create an identity object and download a new avatar unlesss it needs to
         // be updated.
-        if (existing is null || ((DateTime.Now.Ticks - existing.TimeUpdated) > UpdateThreshold))
+        if (existing is null || ((DateTime.Now.Ticks - existing.TimeUpdated) > UpdateThreshold) || string.IsNullOrEmpty(existing.Avatar))
         {
             var newIdentity = CreateFromIdentityRef(identityRef, connection);
             return AddOrUpdateIdentity(dataStore, newIdentity);

--- a/src/AzureExtension/DataModel/DataObjects/Identity.cs
+++ b/src/AzureExtension/DataModel/DataObjects/Identity.cs
@@ -6,6 +6,8 @@ using System.Text.Json.Serialization;
 using Dapper;
 using Dapper.Contrib.Extensions;
 using DevHomeAzureExtension.Helpers;
+using Microsoft.VisualStudio.Services.Profile;
+using Microsoft.VisualStudio.Services.Profile.Client;
 using Microsoft.VisualStudio.Services.WebApi;
 
 namespace DevHomeAzureExtension.DataModel;
@@ -15,8 +17,10 @@ public class Identity
 {
     // This is the time between seeing a potential updated Identity record and updating it.
     // This value / 2 is the average time between Identity updating their Identity data and having
-    // it reflected in the datastore.
-    private static readonly long UpdateThreshold = TimeSpan.FromHours(4).Ticks;
+    // it reflected in the datastore. We expect identity data to change very infrequently.
+    // Since updating an identity involves re-fetching an avatar image, we want to do this
+    // infrequently.
+    private static readonly long UpdateThreshold = TimeSpan.FromDays(3).Ticks;
 
     [Key]
     [JsonIgnore]
@@ -40,6 +44,22 @@ public class Identity
     public string ToJson() => JsonSerializer.Serialize(this);
 
     public override string ToString() => Name;
+
+    public static string GetAvatar(VssConnection connection, Guid identity)
+    {
+        try
+        {
+            var client = connection.GetClient<ProfileHttpClient>();
+            var avatar = client.GetAvatarAsync(identity, AvatarSize.Small).Result;
+            Log.Logger()?.ReportDebug($"Avatar found: {avatar.Value.Length} bytes.");
+            return Convert.ToBase64String(avatar.Value);
+        }
+        catch (Exception ex)
+        {
+            Log.Logger()?.ReportWarn($"Failed getting Avatar for {identity}.", ex);
+            return string.Empty;
+        }
+    }
 
     public static Identity? FromJson(DataStore dataStore, string json)
     {
@@ -65,7 +85,7 @@ public class Identity
         }
     }
 
-    private static Identity CreateFromIdentityRef(IdentityRef identityRef)
+    private static Identity CreateFromIdentityRef(IdentityRef identityRef, VssConnection connection)
     {
         // It is possible the IdentityRef object content is null but contains
         // a display name like "Closed". This is what is given to work items
@@ -81,7 +101,7 @@ public class Identity
                 // real identity guids.
                 InternalId = identityRef.DisplayName,
                 Name = identityRef.DisplayName,
-                Avatar = Links.GetLinkHref(identityRef.Links, "avatar"),
+                Avatar = string.Empty,
                 TimeUpdated = DateTime.Now.ToDataStoreInteger(),
             };
         }
@@ -90,7 +110,7 @@ public class Identity
         {
             InternalId = identityRef.Id,
             Name = identityRef.DisplayName,
-            Avatar = Links.GetLinkHref(identityRef.Links, "avatar"),
+            Avatar = GetAvatar(connection, new Guid(identityRef.Id)),
             TimeUpdated = DateTime.Now.ToDataStoreInteger(),
         };
     }
@@ -101,20 +121,9 @@ public class Identity
         var existingIdentity = GetByInternalId(dataStore, identity.InternalId);
         if (existingIdentity is not null)
         {
-            // Many of the same Identity records will be created on a sync, and to
-            // avoid unnecessary updating and database operations for data that
-            // is extremely unlikely to have changed in any significant way, we
-            // will only update every UpdateThreshold amount of time.
-            if ((identity.TimeUpdated - existingIdentity.TimeUpdated) > UpdateThreshold)
-            {
-                identity.Id = existingIdentity.Id;
-                dataStore.Connection!.Update(identity);
-                return identity;
-            }
-            else
-            {
-                return existingIdentity;
-            }
+            identity.Id = existingIdentity.Id;
+            dataStore.Connection!.Update(identity);
+            return identity;
         }
 
         // No existing pull request, add it.
@@ -144,15 +153,33 @@ public class Identity
         return dataStore.Connection!.QueryFirstOrDefault<Identity>(sql, param, null);
     }
 
-    public static Identity GetOrCreateIdentity(DataStore dataStore, IdentityRef? identityRef)
+    public static Identity GetOrCreateIdentity(DataStore dataStore, IdentityRef? identityRef, VssConnection connection)
     {
         if (identityRef == null)
         {
             throw new ArgumentNullException(nameof(identityRef));
         }
 
-        var newIdentity = CreateFromIdentityRef(identityRef);
-        return AddOrUpdateIdentity(dataStore, newIdentity);
+        Identity? existing;
+        if (identityRef.Id == null)
+        {
+            existing = GetByInternalId(dataStore, identityRef.DisplayName);
+        }
+        else
+        {
+            existing = GetByInternalId(dataStore, identityRef.Id);
+        }
+
+        // Check for whether we need to update the record.
+        // We don't want to create an identity object and download a new avatar unlesss it needs to
+        // be updated.
+        if (existing is null || ((DateTime.Now.Ticks - existing.TimeUpdated) > UpdateThreshold))
+        {
+            var newIdentity = CreateFromIdentityRef(identityRef, connection);
+            return AddOrUpdateIdentity(dataStore, newIdentity);
+        }
+
+        return existing;
     }
 
     public static void DeleteBefore(DataStore dataStore, DateTime date)

--- a/src/AzureExtension/Widgets/Templates/AzurePullRequestsTemplate.json
+++ b/src/AzureExtension/Widgets/Templates/AzurePullRequestsTemplate.json
@@ -42,7 +42,7 @@
                 {
                   "type": "Image",
                   "style": "Person",
-                  "url": "${avatar}",
+                  "url": "data:image/png;base64,${avatar}",
                   "height": "25px"
                 }
               ],

--- a/src/AzureExtension/Widgets/Templates/AzureQueryListTemplate.json
+++ b/src/AzureExtension/Widgets/Templates/AzureQueryListTemplate.json
@@ -69,7 +69,7 @@
                         {
                           "type": "Image",
                           "style": "Person",
-                          "url": "${avatar}",
+                          "url": "data:image/png;base64,${avatar}",
                           "size": "small"
                         }
                       ]


### PR DESCRIPTION
## Summary of the pull request
The widgets were previously missing user avatars due to the widget renderer not having access to the avatar links since it was a public web client, not an authenticated client. This change adds avatar caching to the data sync for a user record and stores the avatar in the datastore. This works around the permission issue as all of the data is being pulled from the Datastore instead of trying to fetch the icons from the web. This is also a performance improvement since each icon is only cached once and infrequently updated.

## References and relevant issues
Closes #115 

## Detailed description of the pull request / Additional comments
* Updated the Identity data object to fetch avatars and store them as a base64 encoded string.
* Updated the Identity object to only fetch avatars when it is updated.
* Changed updated staleness value to three days. This means user avatars will only be re-downloaded once every three days. This allows updates to a user's avatar to be reflected, but as this is unlikely to happen very often the update may be delayed. This value is easy to change should we wish to tune it later.
* Updated the data sync to pass in the connection object when creating identity records so the avatar can be fetched.
* Updated the widget templates to read avatars as an image instead of a link.

## Validation steps performed
* Verified functionality of avatars with several different queries and the query list widget and pull request widget.

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
