### PR TITLE
Change AzureDevOps requested scope to .default

### DIFF
--- a/src/AzureExtension/DeveloperId/AuthenticationSettings.cs
+++ b/src/AzureExtension/DeveloperId/AuthenticationSettings.cs
@@ -67,6 +67,6 @@ public class AuthenticationSettings
         RedirectURI = "ms-appx-web://microsoft.aad.brokerplugin/{0}";
         CacheFileName = "msal_cache";
         CacheDir = ApplicationData.Current != null ? ApplicationData.Current.LocalFolder.Path : cacheFolderPathDefault;
-        Scopes = "499b84ac-1321-427f-aa17-267ca6975798/user_impersonation";
+        Scopes = "499b84ac-1321-427f-aa17-267ca6975798/.default";
     }
 }


### PR DESCRIPTION
## Summary of the pull request
Change AzureDevOps requested scope to .default

## Detailed description of the pull request / Additional comments
AzureDevOps are providing more granular scopes available. For this purpose, the .default scope should be requested in advance (i.e. specific scopes should not be individually requested).  Requesting .default does ensure that the list of scopes preauthorized for the application are granted. 

## Validation steps performed
Ran unit tests
Manual testing of developer id scenarios

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
