### PR TITLE
Update AzureUri for onprem support and handle VssResourceNotFound error

### DIFF
--- a/src/AzureExtension/Client/AzureClientHelpers.cs
+++ b/src/AzureExtension/Client/AzureClientHelpers.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.TeamFoundation.SourceControl.WebApi;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
+using Microsoft.VisualStudio.Services.WebApi;
 
 namespace DevHomeAzureExtension.Client;
 
@@ -52,8 +53,16 @@ public class AzureClientHelpers
         }
         catch (Exception ex)
         {
-            Log.Logger()?.ReportError($"Failed getting query info for: {azureUri}", ex);
-            return new InfoResult(azureUri, InfoType.Query, ResultType.Failure, ErrorType.Unknown, ex);
+            if (ex.InnerException is VssResourceNotFoundException)
+            {
+                Log.Logger()?.ReportError($"Vss Resource Not Found for {azureUri}", ex);
+                return new InfoResult(azureUri, InfoType.Query, ResultType.Failure, ErrorType.VssResourceNotFound, ex);
+            }
+            else
+            {
+                Log.Logger()?.ReportError($"Failed getting query info for: {azureUri}", ex);
+                return new InfoResult(azureUri, InfoType.Query, ResultType.Failure, ErrorType.Unknown, ex);
+            }
         }
     }
 
@@ -111,8 +120,16 @@ public class AzureClientHelpers
         }
         catch (Exception ex)
         {
-            Log.Logger()?.ReportError($"Failed getting repository info for: {azureUri}", ex);
-            return new InfoResult(azureUri, InfoType.Repository, ResultType.Failure, ErrorType.Unknown, ex);
+            if (ex.InnerException is VssResourceNotFoundException)
+            {
+                Log.Logger()?.ReportError($"Vss Resource Not Found for {azureUri}", ex);
+                return new InfoResult(azureUri, InfoType.Repository, ResultType.Failure, ErrorType.VssResourceNotFound, ex);
+            }
+            else
+            {
+                Log.Logger()?.ReportError($"Failed getting repository info for: {azureUri}", ex);
+                return new InfoResult(azureUri, InfoType.Repository, ResultType.Failure, ErrorType.Unknown, ex);
+            }
         }
     }
 

--- a/src/AzureExtension/Client/AzureClientProvider.cs
+++ b/src/AzureExtension/Client/AzureClientProvider.cs
@@ -132,14 +132,17 @@ public class AzureClientProvider
                 Log.Logger()?.ReportInfo($"Created new connection to {azureUri.Connection} for {developerId.LoginId}");
                 return new ConnectionResult(azureUri.Connection, null, connection);
             }
+            else
+            {
+                Log.Logger()?.ReportError($"Connection to {azureUri.Connection} was null.");
+                return new ConnectionResult(ResultType.Failure, ErrorType.NullConnection, false);
+            }
         }
         catch (Exception ex)
         {
             Log.Logger()?.ReportError($"Unable to establish VssConnection: {ex}");
             return new ConnectionResult(ResultType.Failure, ErrorType.InitializeVssConnectionFailure, true, ex);
         }
-
-        return new ConnectionResult(ResultType.Failure, ErrorType.Unknown, false);
     }
 
     /// <summary>

--- a/src/AzureExtension/Client/ErrorType.cs
+++ b/src/AzureExtension/Client/ErrorType.cs
@@ -22,4 +22,6 @@ public enum ErrorType
     MsalClientError,
     GenericCredentialFailure,
     InitializeVssConnectionFailure,
+    NullConnection,
+    VssResourceNotFound,
 }

--- a/src/AzureExtension/Strings/en-US/Resources.resw
+++ b/src/AzureExtension/Strings/en-US/Resources.resw
@@ -342,4 +342,17 @@
     <value>Loading content...</value>
     <comment>Shown in Widget when first pinned while waiting for data to load.</comment>
   </data>
+  <data name="ErrorMessage.InitializeVssConnectionFailure" xml:space="preserve">
+    <value>Failed creating the Vss Connection</value>
+  </data>
+  <data name="ErrorMessage.NullConnection" xml:space="preserve">
+    <value>The connection result was null.</value>
+  </data>
+  <data name="ErrorMessage.Unknown" xml:space="preserve">
+    <value>An unknown error occurred.</value>
+  </data>
+  <data name="ErrorMessage.VssResourceNotFound" xml:space="preserve">
+    <value>The Azure server does not support this functionality.</value>
+    <comment>Shown in widget on error.</comment>
+  </data>
 </root>

--- a/test/AzureExtension/RepositoryProvider/RepositoryProviderTests.cs
+++ b/test/AzureExtension/RepositoryProvider/RepositoryProviderTests.cs
@@ -132,7 +132,7 @@ public partial class RepositoryProviderTests
         {
             TestContext?.WriteLine($"Testing {invalidUrl}");
             var myAzureUri = new AzureUri(invalidUrl);
-            Assert.IsFalse(myAzureUri.IsValid);
+            Assert.IsFalse(myAzureUri.IsHosted);
             Assert.IsFalse(myAzureUri.IsRepository);
         }
 

--- a/test/AzureExtension/Widgets/Validation.cs
+++ b/test/AzureExtension/Widgets/Validation.cs
@@ -155,6 +155,27 @@ public partial class WidgetTests
             Tuple.Create("https://organization.vssps.visualstudio.com/with/extra/stuff", AzureUriType.SignIn, false),
             Tuple.Create("https://organization.vssps.visualstudio.com:443/", AzureUriType.SignIn, false),
             Tuple.Create("https://organization.vssps.visualstudio.com:443/with/extra/stuff", AzureUriType.SignIn, false),
+
+            // On-Prem test URIs.
+            // Repositories
+            Tuple.Create("https://organization/project/_git/repository", AzureUriType.Repository, false),
+            Tuple.Create("https://organization/project/_git/repository/", AzureUriType.Repository, false),
+            Tuple.Create("https://organization/project/_git/repository/some/other/stuff", AzureUriType.Repository, false),
+            Tuple.Create("https://organization/collection/project/_git/repository", AzureUriType.Repository, false),
+            Tuple.Create("https://organization/collection/project/_git/repository/", AzureUriType.Repository, false),
+            Tuple.Create("https://organization/collection/project/_git/repository/some/other/stuff", AzureUriType.Repository, false),
+
+            // Work item link
+            Tuple.Create("https://organization/project/_workitems/edit/1234567", AzureUriType.WorkItem, false),
+            Tuple.Create("https://organization/project/_workitems/edit/1234567/", AzureUriType.WorkItem, false),
+            Tuple.Create("https://organization/collection/project/_workitems/edit/1234567", AzureUriType.WorkItem, false),
+            Tuple.Create("https://organization/collection/project/_workitems/edit/1234567/", AzureUriType.WorkItem, false),
+
+            // Queries
+            Tuple.Create("https://organization/project/_queries/query/12345678-1234-1234-1234-1234567890ab", AzureUriType.Query, false),
+            Tuple.Create("https://organization/project/_queries/query/12345678-1234-1234-1234-1234567890ab/", AzureUriType.Query, false),
+            Tuple.Create("https://organization/collection/project/_queries/query/12345678-1234-1234-1234-1234567890ab", AzureUriType.Query, false),
+            Tuple.Create("https://organization/collection/project/_queries/query/12345678-1234-1234-1234-1234567890ab/", AzureUriType.Query, false),
         };
 
         var testUrisInvalid = new List<Tuple<string, AzureUriType, bool>>
@@ -187,10 +208,8 @@ public partial class WidgetTests
 
             // All Valid inputs should be valid.
             Assert.IsTrue(azureUri.IsValid);
-
-            // We only support hosted for now.
-            Assert.IsTrue(azureUri.IsHosted);
-            TestContext?.WriteLine($"Org: {azureUri.Organization}  Project: {azureUri.Project}  Repository: {azureUri.Repository}  Query: {azureUri.Query}");
+            Assert.IsTrue(azureUri.HostType != AzureHostType.Unknown);
+            TestContext?.WriteLine($"Org: {azureUri.Organization}  Project: {azureUri.Project}  Repository: {azureUri.Repository}  Query: {azureUri.Query}  HostType: {azureUri.HostType}");
 
             if (uriTuple.Item2 != AzureUriType.SignIn && uriTuple.Item2 != AzureUriType.RepositoryNoProject && uriTuple.Item2 != AzureUriType.NamesWithSpaces)
             {
@@ -316,15 +335,14 @@ public partial class WidgetTests
         }
 
         // Verify bad strings are recognized as bad.
+        // Not-Hosted Uris might have valid organization or project values, but should not be valid
+        // for Repositories or Queries.
         foreach (var uriTuple in testUrisInvalid)
         {
             TestContext?.WriteLine($"Uri: {uriTuple.Item1}   Type: {uriTuple.Item2}  IsLegacy: {uriTuple.Item3}");
             var azureUri = new AzureUri(uriTuple.Item1);
-            Assert.IsFalse(azureUri.IsValid);
             Assert.IsFalse(azureUri.IsHosted);
             Assert.AreEqual(uriTuple.Item1, azureUri.OriginalString);
-            Assert.AreEqual(string.Empty, azureUri.Organization);
-            Assert.AreEqual(string.Empty, azureUri.Project);
             Assert.IsFalse(azureUri.IsRepository);
             Assert.AreEqual(string.Empty, azureUri.Repository);
             Assert.IsFalse(azureUri.IsQuery);
@@ -348,11 +366,8 @@ public partial class WidgetTests
                 Assert.AreEqual(azureUri.Uri, uri);
 
                 // Re-validate all of the properties are the same using this constructor.
-                Assert.IsFalse(azureUri.IsValid);
                 Assert.IsFalse(azureUri.IsHosted);
                 Assert.AreEqual(uriTuple.Item1, azureUri.OriginalString);
-                Assert.AreEqual(string.Empty, azureUri.Organization);
-                Assert.AreEqual(string.Empty, azureUri.Project);
                 Assert.IsFalse(azureUri.IsRepository);
                 Assert.AreEqual(string.Empty, azureUri.Repository);
                 Assert.IsFalse(azureUri.IsQuery);


### PR DESCRIPTION
## Summary of the pull request

Updates AzureUri to handle the format for On-Premeses DevOps servers (aka "onprem"). 

Also adds a specific error handling message for VssResourceNotFound error, which is what happens if you call an API that the devops server does not support. This was found against a DevOps Express install, which does not appear to have full rest API functionality.

## References and relevant issues

Closes #45

## Detailed description of the pull request / Additional comments

* Updated AzureUri to support onprem format URIs.
* Updated some error handling to check for the VssResourceNotFound exception.
* Added some error handling strings that were missing which were hit while working on this feature.
* Better handling of the null case of connections, which I encountered when testing onprem.
* Updated the Validation tests for AzureUri to validate on-prem style Uris.
* Updated RepositoryProvider uri validation test to account for the now less-rigid valid formats.

## Validation steps performed

* Installed DevOps express, created on-prem server local to my machine and tested the code against URLs to my local devops server.
* Verified new onprem validation tests pass and process as expected.
* Verified repositoryprovider Uri testing passes as before.
## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
