### PR TITLE
Rename logfile extension

### DIFF
--- a/src/AzureExtension/Client/Logging.cs
+++ b/src/AzureExtension/Client/Logging.cs
@@ -41,7 +41,7 @@ public class Log
         return new Options
         {
             LogFileFolderRoot = ApplicationData.Current.TemporaryFolder.Path,
-            LogFileName = $"{_loggerName}_{{now}}.log",
+            LogFileName = $"{_loggerName}_{{now}}.dhlog",
             LogFileFolderName = _loggerName,
             DebugListenerEnabled = true,
 #if DEBUG

--- a/src/AzureExtension/DataModel/Logging.cs
+++ b/src/AzureExtension/DataModel/Logging.cs
@@ -39,7 +39,7 @@ public class Log
         return new Options
         {
             LogFileFolderRoot = ApplicationData.Current.TemporaryFolder.Path,
-            LogFileName = "DataStore_{now}.log",
+            LogFileName = "DataStore_{now}.dhlog",
             LogFileFolderName = "DataStore",
             DebugListenerEnabled = true,
 #if DEBUG

--- a/src/AzureExtension/DeveloperId/Logging.cs
+++ b/src/AzureExtension/DeveloperId/Logging.cs
@@ -39,7 +39,7 @@ public class Log
         return new Options
         {
             LogFileFolderRoot = ApplicationData.Current.TemporaryFolder.Path,
-            LogFileName = "DeveloperId_{now}.log",
+            LogFileName = "DeveloperId_{now}.dhlog",
             LogFileFolderName = "DeveloperId",
             DebugListenerEnabled = true,
 #if DEBUG

--- a/src/AzureExtension/Notifications/Logging.cs
+++ b/src/AzureExtension/Notifications/Logging.cs
@@ -39,7 +39,7 @@ public class Log
         return new Options
         {
             LogFileFolderRoot = ApplicationData.Current.TemporaryFolder.Path,
-            LogFileName = "Notifications_{now}.log",
+            LogFileName = "Notifications_{now}.dhlog",
             LogFileFolderName = "Notifications",
             DebugListenerEnabled = true,
 #if DEBUG

--- a/src/AzureExtension/Providers/Logging.cs
+++ b/src/AzureExtension/Providers/Logging.cs
@@ -30,7 +30,7 @@ public class Log
         return new Options
         {
             LogFileFolderRoot = ApplicationData.Current.TemporaryFolder.Path,
-            LogFileName = "AzureExtension_{now}.log",
+            LogFileName = "AzureExtension_{now}.dhlog",
             LogFileFolderName = "AzureExtension",
             DebugListenerEnabled = true,
 #if DEBUG

--- a/src/AzureExtension/Widgets/Logging.cs
+++ b/src/AzureExtension/Widgets/Logging.cs
@@ -30,7 +30,7 @@ public class Log
         return new Options
         {
             LogFileFolderRoot = ApplicationData.Current.TemporaryFolder.Path,
-            LogFileName = "Widgets_{now}.log",
+            LogFileName = "Widgets_{now}.dhlog",
             LogFileFolderName = "Widgets",
             DebugListenerEnabled = true,
 #if DEBUG

--- a/src/AzureExtensionServer/Logging.cs
+++ b/src/AzureExtensionServer/Logging.cs
@@ -30,7 +30,7 @@ public class Log
         return new Options
         {
             LogFileFolderRoot = ApplicationData.Current.TemporaryFolder.Path,
-            LogFileName = "ExtensionServer_{now}.log",
+            LogFileName = "ExtensionServer_{now}.dhlog",
             LogFileFolderName = "ExtensionServer",
             DebugListenerEnabled = true,
 #if DEBUG

--- a/src/Logging/listeners/LogFileListenerOptions.cs
+++ b/src/Logging/listeners/LogFileListenerOptions.cs
@@ -5,7 +5,7 @@ namespace DevHome.Logging;
 
 public partial class Options
 {
-    private const string LogFileNameDefault = "DevHomeAzureExtension.log";
+    private const string LogFileNameDefault = "DevHomeAzureExtension.dhlog";
     private const string LogFileFolderNameDefault = "{now}";
 
     public string LogFileName { get; set; } = LogFileNameDefault;

--- a/test/AzureExtension/Helpers/TestSetupHelpers.cs
+++ b/test/AzureExtension/Helpers/TestSetupHelpers.cs
@@ -10,7 +10,7 @@ namespace DevHomeAzureExtension.Test;
 public partial class TestHelpers
 {
     private const string DataBaseFileName = "AzureExtension-Test.db";
-    private const string LogFileName = "AzureExtension-{now}.log";
+    private const string LogFileName = "AzureExtension-{now}.dhlog";
     private static readonly TimeSpan CleanupRetryWaitTime = TimeSpan.FromSeconds(10);
 
     public static void CleanupTempTestOptions(TestOptions options, TestContext context)


### PR DESCRIPTION
## Summary of the pull request
Renames the extension of the logs to ".dhlog".  The previous extension, ".log" is very generic and does not have any implication of format of the log file. For tooling to better read, parse, and gather Dev Home logs this change was made to something more specific to Dev Home while still being human-readable and easily identifiable as a log file.

We do not require absolute uniqueness here, and I did not find any common or known file extensions today that use ".dhlog", so this is reasonably and sufficiently unique for our purposes of improving dev home log identification.

After this is changed I will change it in DevHome and the github extension as well. I wanted to start with one PR for the name change so if there is objection or differences the feedback can be incorporated in one place first.
 
## References and relevant issues

## Detailed description of the pull request / Additional comments
* Logfile extension name changed from ".log" to ".dhlog"

## Validation steps performed
* Verified all the logfiles are the new extension.
* Verified tests pass and the tests are also logging to the correct name.

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
