### PR TITLE
Re-enable Json Serializer reflection

### DIFF
--- a/src/AzureExtensionServer/AzureExtensionServer.csproj
+++ b/src/AzureExtensionServer/AzureExtensionServer.csproj
@@ -22,6 +22,7 @@
     <PublishProfile Condition="'$(BuildingInsideVisualStudio)' != 'True'">Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
     <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
     <TrimMode>partial</TrimMode>
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <ILLinkTreatWarningsAsErrors>false</ILLinkTreatWarningsAsErrors>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>


### PR DESCRIPTION
## Summary of the pull request

Re-enables the Json Serializer Reflection, which was disabled by default inadvertently in .Net 8.

## References and relevant issues
#134 

## Detailed description of the pull request / Additional comments
Re-enables Json Serializer Reflection. This was default behavior in .Net 7 and previous, and was default disabled due to publishing settings involving trimming with .Net 8. This fix restores us to pre-.Net 8 behavior.

There's a more involved fix if we want to keep the serializer reflection disabled for Native AOT builds, but this unblocks us and gets the extension working.

## Validation steps performed
* Tested debug and release builds with and without the build setting enabled. With setting set to false, data update fails with serializer reflection error. with setting set to true, data update succeeds as before and widgets work.

## PR checklist
- [x] Closes #134
- [x] Tests added/passed
- [x] Documentation updated
