### PR TITLE
Environments: Updated Dev Box State logic

### DIFF
--- a/src/AzureExtension/DevBox/Constants.cs
+++ b/src/AzureExtension/DevBox/Constants.cs
@@ -88,31 +88,64 @@ public static class Constants
 
     public const string DevBoxRepairOperation = "repair";
 
-    public const string DevBoxCreatingProvisioningState = "Creating";
-
-    public const string DevBoxProvisioningState = "Provisioning";
-
-    public const string DevBoxProvisioningFailedState = "ProvisioningFailed";
-
-    public const string DevBoxUnknownState = "Unknown";
-
-    public const string DevBoxRunningState = "Running";
-
-    public const string DevBoxDeallocatedState = "Deallocated";
-
-    public const string DevBoxPoweredOffState = "PoweredOff";
-
-    public const string DevBoxHibernatedState = "Hibernated";
-
     public const string DevBoxDeletedState = "Deleted";
 
     public const string DevBoxOperationNotStartedState = "NotStarted";
 
-    public const string DevBoxOperationSucceededState = "Succeeded";
+    public static class DevBoxProvisioningStates
+    {
+        public const string Succeeded = "Succeeded";
 
-    public const string DevBoxOperationCanceledState = "Canceled";
+        public const string Failed = "Failed";
 
-    public const string DevBoxOperationFailedState = "Failed";
+        public const string Canceled = "Canceled";
+
+        public const string ProvisionedWithWarning = "ProvisionedWithWarning";
+
+        public const string Provisioning = "Provisioning";
+
+        public const string Creating = "Creating";
+
+        public const string Deleting = "Deleting";
+
+        public const string Updating = "Updating";
+    }
+
+    public static class DevBoxActionStates
+    {
+        public const string Unknown = "Unknown";
+
+        public const string Failed = "Failed";
+
+        public const string Starting = "Starting";
+
+        public const string Started = "Started";
+
+        public const string Stopping = "Stopping";
+
+        public const string Stopped = "Stopped";
+
+        public const string Restarting = "Restarting";
+
+        public const string Repairing = "Repairing";
+
+        public const string Repaired = "Repaired";
+    }
+
+    public static class DevBoxPowerStates
+    {
+        public const string Unknown = "Unknown";
+
+        public const string Stopped = "Stopped";
+
+        public const string Running = "Running";
+
+        public const string Hibernated = "Hibernated";
+
+        public const string Deallocated = "Deallocated";
+
+        public const string PoweredOff = "PoweredOff";
+    }
 
     /// <summary>
     /// The JSON options used to deserialize the DevCenter API responses.

--- a/src/AzureExtension/DevBox/DevBoxInstance.cs
+++ b/src/AzureExtension/DevBox/DevBoxInstance.cs
@@ -65,7 +65,7 @@ public class DevBoxInstance : IComputeSystem
 
     public DevBoxActionToPerform CurrentActionToPerform { get; private set; }
 
-    public bool IsDevBoxBeingCreatedOrProvisioned => DevBoxState.ProvisioningState == Constants.DevBoxCreatingProvisioningState || DevBoxState.ProvisioningState == Constants.DevBoxProvisioningState;
+    public bool IsDevBoxBeingCreatedOrProvisioned => DevBoxState.ProvisioningState == Constants.DevBoxProvisioningStates.Creating || DevBoxState.ProvisioningState == Constants.DevBoxProvisioningStates.Provisioning;
 
     public DevBoxRemoteConnectionData? RemoteConnectionData { get; private set; }
 
@@ -215,8 +215,8 @@ public class DevBoxInstance : IComputeSystem
         {
             // If the provisioning failed, we'll set the state to failed and powerstate to unknown.
             // The PowerState being unknown will make the UI show the Dev Box state as unknown.
-            DevBoxState.ProvisioningState = Constants.DevBoxProvisioningFailedState;
-            DevBoxState.PowerState = Constants.DevBoxUnknownState;
+            DevBoxState.ProvisioningState = Constants.DevBoxProvisioningStates.Failed;
+            DevBoxState.PowerState = Constants.DevBoxPowerStates.Unknown;
         }
 
         RemoveOperationInProgressFlag();
@@ -275,8 +275,8 @@ public class DevBoxInstance : IComputeSystem
             catch (Exception ex)
             {
                 Log.Logger()?.ReportError(DevBoxInstanceName, $"Error setting state after the long running operation completed successfully", ex);
-                DevBoxState.ProvisioningState = Constants.DevBoxProvisioningFailedState;
-                DevBoxState.PowerState = Constants.DevBoxUnknownState;
+                DevBoxState.ProvisioningState = Constants.DevBoxProvisioningStates.Failed;
+                DevBoxState.PowerState = Constants.DevBoxPowerStates.Unknown;
                 RemoveOperationInProgressFlag();
                 UpdateStateForUI();
             }
@@ -288,34 +288,91 @@ public class DevBoxInstance : IComputeSystem
         StateChanged?.Invoke(this, GetState());
     }
 
+    private bool IsTerminalProvisioningState(string provisioningState)
+    {
+        return provisioningState == Constants.DevBoxProvisioningStates.Succeeded
+            || provisioningState == Constants.DevBoxProvisioningStates.ProvisionedWithWarning
+            || provisioningState == Constants.DevBoxProvisioningStates.Canceled
+            || provisioningState == Constants.DevBoxProvisioningStates.Failed;
+    }
+
+    private bool IsTerminalActionState(string actionState)
+    {
+        return actionState == Constants.DevBoxActionStates.Started
+            || actionState == Constants.DevBoxActionStates.Stopped
+            || actionState == Constants.DevBoxActionStates.Repaired
+            || actionState == Constants.DevBoxActionStates.Unknown
+            || actionState == Constants.DevBoxActionStates.Failed;
+    }
+
     public ComputeSystemState GetState()
     {
-        switch (DevBoxState.ProvisioningState)
-        {
-            case Constants.DevBoxCreatingProvisioningState:
-            case Constants.DevBoxProvisioningState:
-                return ComputeSystemState.Creating;
-            case Constants.DevBoxDeletedState:
-                return ComputeSystemState.Deleted;
+        var provisioningState = DevBoxState.ProvisioningState;
+        var actionState = DevBoxState.ActionState;
+        var powerState = DevBoxState.PowerState;
 
-            // Fallthrough if we're not creating/provisioning and the Dev Box exists.
-            // We'll look at the the power state next to figure out what state to send
-            // to Dev Home.
+        // This state is actually failed, but since ComputeSystemState doesn't have a failed state, we'll return unknown.
+        if (provisioningState == Constants.DevBoxProvisioningStates.Failed
+            || provisioningState == Constants.DevBoxProvisioningStates.ProvisionedWithWarning)
+        {
+            return ComputeSystemState.Unknown;
         }
 
-        switch (DevBoxState.PowerState)
+        if (!IsTerminalProvisioningState(provisioningState))
         {
-            case Constants.DevBoxRunningState:
-                return ComputeSystemState.Running;
+            switch (provisioningState)
+            {
+                case Constants.DevBoxProvisioningStates.Provisioning:
+                case Constants.DevBoxProvisioningStates.Creating:
+                    return ComputeSystemState.Creating;
+                case Constants.DevBoxProvisioningStates.Deleting:
+                    return ComputeSystemState.Deleting;
+            }
+        }
 
-            // We don't have a direct mapping for the hiberbated state and may need to add one one day.
-            case Constants.DevBoxHibernatedState:
-            case Constants.DevBoxDeallocatedState:
-            case Constants.DevBoxPoweredOffState:
+        if (!IsTerminalActionState(actionState))
+        {
+            switch (actionState)
+            {
+                case Constants.DevBoxActionStates.Starting:
+                    return ComputeSystemState.Starting;
+                case Constants.DevBoxActionStates.Stopping:
+                    return ComputeSystemState.Stopping;
+                case Constants.DevBoxActionStates.Restarting:
+                    return ComputeSystemState.Restarting;
+
+                // This state is actually repairing, but since ComputeSystemState doesn't have a repairing state, we'll return starting.
+                case Constants.DevBoxActionStates.Repairing:
+                    return ComputeSystemState.Starting;
+            }
+        }
+
+        switch (powerState)
+        {
+            case Constants.DevBoxPowerStates.Running:
+                return ComputeSystemState.Running;
+            case Constants.DevBoxPowerStates.Hibernated:
+                return ComputeSystemState.Paused;
+            case Constants.DevBoxPowerStates.Stopped:
+            case Constants.DevBoxPowerStates.Deallocated:
+            case Constants.DevBoxPowerStates.PoweredOff:
                 return ComputeSystemState.Stopped;
-            default:
+        }
+
+        // This is a workaround from the web app for not getting power state for new VMs.
+        switch (actionState)
+        {
+            case Constants.DevBoxActionStates.Unknown:
+            case Constants.DevBoxActionStates.Stopped:
+                return ComputeSystemState.Stopped;
+            case Constants.DevBoxActionStates.Started:
+                return ComputeSystemState.Running;
+            case Constants.DevBoxActionStates.Failed:
                 return ComputeSystemState.Unknown;
         }
+
+        // If we reach this point, we are not sure of the state of the dev box so return unknown instead.
+        return ComputeSystemState.Unknown;
     }
 
     public IAsyncOperation<ComputeSystemOperationResult> StartAsync(string options)

--- a/src/AzureExtension/DevBox/DevBoxInstance.cs
+++ b/src/AzureExtension/DevBox/DevBoxInstance.cs
@@ -354,7 +354,7 @@ public class DevBoxInstance : IComputeSystem
             case Constants.DevBoxPowerStates.Running:
                 return ComputeSystemState.Running;
             case Constants.DevBoxPowerStates.Hibernated:
-                return ComputeSystemState.Paused;
+                return ComputeSystemState.Saved;
             case Constants.DevBoxPowerStates.Stopped:
             case Constants.DevBoxPowerStates.Deallocated:
             case Constants.DevBoxPowerStates.PoweredOff:

--- a/src/AzureExtension/DevBox/DevBoxInstance.cs
+++ b/src/AzureExtension/DevBox/DevBoxInstance.cs
@@ -288,6 +288,7 @@ public class DevBoxInstance : IComputeSystem
         StateChanged?.Invoke(this, GetState());
     }
 
+    // Check if it is a final provisioning state
     private bool IsTerminalProvisioningState(string provisioningState)
     {
         return provisioningState == Constants.DevBoxProvisioningStates.Succeeded
@@ -296,6 +297,7 @@ public class DevBoxInstance : IComputeSystem
             || provisioningState == Constants.DevBoxProvisioningStates.Failed;
     }
 
+    // Check if it is a final action state
     private bool IsTerminalActionState(string actionState)
     {
         return actionState == Constants.DevBoxActionStates.Started

--- a/src/AzureExtension/Services/DevBox/DevBoxCreationManager.cs
+++ b/src/AzureExtension/Services/DevBox/DevBoxCreationManager.cs
@@ -91,7 +91,7 @@ public class DevBoxCreationManager : IDevBoxCreationManager
                         RemoveDevBoxFromMap(devBox);
 
                         // The Dev Box is now ready for use. No need to request a new Dev Box from the Dev Center. We can update the state for Dev Homes UI.
-                        devBox.DevBoxState.ProvisioningState = Constants.DevBoxOperationSucceededState;
+                        devBox.DevBoxState.ProvisioningState = Constants.DevBoxProvisioningStates.Succeeded;
                         devBox.UpdateStateForUI();
                         break;
                     default:

--- a/src/AzureExtension/Services/DevBox/DevBoxOperationWatcher.cs
+++ b/src/AzureExtension/Services/DevBox/DevBoxOperationWatcher.cs
@@ -135,7 +135,7 @@ public class DevBoxOperationWatcher : IDevBoxOperationWatcher
                     var devBoxState = JsonSerializer.Deserialize<DevBoxMachineState>(result.JsonResponseRoot.ToString(), Constants.JsonOptions)!;
 
                     // If the Dev Box is no longer being created, update the state for Dev Homes UI and end the timer.
-                    if (!(devBoxState.ProvisioningState == Constants.DevBoxCreatingProvisioningState || devBoxState.ProvisioningState == Constants.DevBoxProvisioningState))
+                    if (!(devBoxState.ProvisioningState == Constants.DevBoxProvisioningStates.Creating || devBoxState.ProvisioningState == Constants.DevBoxProvisioningStates.Provisioning))
                     {
                         Log.Logger()?.ReportInfo(DevBoxOperationWatcherName, $"Dev Box provisioning now completed.");
                         devBoxInstance.ProvisioningMonitorCompleted(devBoxState, ProvisioningStatus.Succeeded);

--- a/test/AzureExtension/DevBox/DevBoxTests.cs
+++ b/test/AzureExtension/DevBox/DevBoxTests.cs
@@ -87,9 +87,9 @@ public partial class DevBoxTests
     {
         // Arrange
         var devBoxList = JsonSerializer.Deserialize<DevBoxMachines>(MockDevBoxListJson, Constants.JsonOptions);
-        devBoxList!.Value![0].PowerState = Constants.DevBoxPoweredOffState;
+        devBoxList!.Value![0].PowerState = Constants.DevBoxPowerStates.PoweredOff;
         var devBoxListPoweredOffJson = JsonSerializer.Serialize(devBoxList!, Constants.JsonOptions);
-        devBoxList!.Value![0].PowerState = Constants.DevBoxRunningState;
+        devBoxList!.Value![0].PowerState = Constants.DevBoxPowerStates.Running;
         var runningDevBox = devBoxList!.Value![0];
         var runningDevBoxJson = JsonSerializer.Serialize(runningDevBox, Constants.JsonOptions);
         var operationCompletedSucceeded = JsonSerializer.Deserialize<DevBoxOperation>(MockTestOperationJson, Constants.JsonOptions);


### PR DESCRIPTION
## Summary of the pull request
On the Environments page performing any operation on a dev box which resulted in a long running operation changed the status of the UI which was lost on pressing Sync. This has been fixed in the PR and now uses the same logic used by the Dev Box webapp to compute the status.

## Validation steps performed
Performed starting, stopping, restarting and deleting to make sure the strings were correct.

![image](https://github.com/microsoft/DevHomeAzureExtension/assets/16077119/fd59d908-2827-4714-a239-01448623d1c5)

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
