### PR TITLE
Fix log timestamp format

### DIFF
--- a/src/AzureExtensionServer/appsettings.json
+++ b/src/AzureExtensionServer/appsettings.json
@@ -6,7 +6,7 @@
       {
         "Name": "Console",
         "Args": {
-          "outputTemplate": "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
+          "outputTemplate": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
           "restrictedToMinimumLevel": "Debug"
         }
       },
@@ -14,7 +14,7 @@
         "Name": "File",
         "Args": {
           "path": "%DEVHOME_LOGS_ROOT%\\log.dhlog",
-          "outputTemplate": "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
+          "outputTemplate": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
           "restrictedToMinimumLevel": "Information",
           "rollingInterval": "Day"
         }

--- a/test/AzureExtension/Helpers/TestSetupHelpers.cs
+++ b/test/AzureExtension/Helpers/TestSetupHelpers.cs
@@ -94,11 +94,11 @@ public partial class TestHelpers
             .WriteTo.File(
                 path: GetLogFilePath(options),
                 formatProvider: CultureInfo.InvariantCulture,
-                outputTemplate: "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}")
+                outputTemplate: "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}")
             .WriteTo.TestContextSink(
                 context: context,
                 formatProvider: CultureInfo.InvariantCulture,
-                outputTemplate: "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}")
+                outputTemplate: "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}")
             .CreateLogger();
     }
 

--- a/test/Console/appsettings.json
+++ b/test/Console/appsettings.json
@@ -6,14 +6,14 @@
       {
         "Name": "Console",
         "Args": {
-          "outputTemplate": "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}"
+          "outputTemplate": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}"
         }
       },
       {
         "Name": "File",
         "Args": {
           "path": "%DEVHOME_LOGS_ROOT%\\log.dhlog",
-          "outputTemplate": "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
+          "outputTemplate": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
           "rollingInterval": "Day"
         }
       },


### PR DESCRIPTION
## Summary of the pull request
Timestamp format was incorrect for the logging, putting minutes instead of months and creating an invalid timestamp. It also fails to parse as a DateTime which broke tooling.

## References and relevant issues
Closes #146 

## Detailed description of the pull request / Additional comments
* Fixed output format to use correct format specifier for Month.

## Validation steps performed
* Launched provider and verified log format is correct and correctly parsed.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
