### PR TITLE
Fix exception logging

### DIFF
--- a/src/AzureExtension/Client/AzureClientHelpers.cs
+++ b/src/AzureExtension/Client/AzureClientHelpers.cs
@@ -57,12 +57,12 @@ public class AzureClientHelpers
         {
             if (ex.InnerException is VssResourceNotFoundException)
             {
-                log.Error($"Vss Resource Not Found for {azureUri}", ex);
+                log.Error(ex, $"Vss Resource Not Found for {azureUri}");
                 return new InfoResult(azureUri, InfoType.Query, ResultType.Failure, ErrorType.VssResourceNotFound, ex);
             }
             else
             {
-                log.Error($"Failed getting query info for: {azureUri}", ex);
+                log.Error(ex, $"Failed getting query info for: {azureUri}");
                 return new InfoResult(azureUri, InfoType.Query, ResultType.Failure, ErrorType.Unknown, ex);
             }
         }
@@ -125,12 +125,12 @@ public class AzureClientHelpers
         {
             if (ex.InnerException is VssResourceNotFoundException)
             {
-                log.Error($"Vss Resource Not Found for {azureUri}", ex);
+                log.Error(ex, $"Vss Resource Not Found for {azureUri}");
                 return new InfoResult(azureUri, InfoType.Repository, ResultType.Failure, ErrorType.VssResourceNotFound, ex);
             }
             else
             {
-                log.Error($"Failed getting repository info for: {azureUri}", ex);
+                log.Error(ex, $"Failed getting repository info for: {azureUri}");
                 return new InfoResult(azureUri, InfoType.Repository, ResultType.Failure, ErrorType.Unknown, ex);
             }
         }

--- a/src/AzureExtension/Client/AzureClientProvider.cs
+++ b/src/AzureExtension/Client/AzureClientProvider.cs
@@ -72,7 +72,7 @@ public class AzureClientProvider
         }
         catch (Exception ex)
         {
-            Log.Error($"Failed creating connection for developer id and {uri} with exception:", ex);
+            Log.Error(ex, $"Failed creating connection for developer id and {uri} with exception:");
         }
 
         return null;

--- a/src/AzureExtension/Client/AzureUri.cs
+++ b/src/AzureExtension/Client/AzureUri.cs
@@ -256,7 +256,7 @@ public class AzureUri
         }
         catch (Exception e)
         {
-            Log.Error($"InitializeOrganization failed for Uri: {Uri}", e);
+            Log.Error(e, $"InitializeOrganization failed for Uri: {Uri}");
             return string.Empty;
         }
     }
@@ -340,7 +340,7 @@ public class AzureUri
         }
         catch (Exception e)
         {
-            Log.Error($"InitializeProject failed for Uri: {Uri}", e);
+            Log.Error(e, $"InitializeProject failed for Uri: {Uri}");
             return string.Empty;
         }
     }
@@ -387,7 +387,7 @@ public class AzureUri
         }
         catch (Exception e)
         {
-            Log.Error($"InitializeRepository failed for Uri: {Uri}", e);
+            Log.Error(e, $"InitializeRepository failed for Uri: {Uri}");
             return string.Empty;
         }
     }
@@ -453,7 +453,7 @@ public class AzureUri
         }
         catch (Exception e)
         {
-            Log.Error($"InitializeQuery failed for Uri: {Uri}", e);
+            Log.Error(e, $"InitializeQuery failed for Uri: {Uri}");
             return string.Empty;
         }
     }

--- a/src/AzureExtension/DataManager/AzureDataManager.cs
+++ b/src/AzureExtension/DataManager/AzureDataManager.cs
@@ -75,7 +75,7 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
         catch (Exception e)
         {
             var log = Log.ForContext("SourceContext", Name);
-            log.Error($"Failed creating AzureDataManager for {identifier}", e);
+            log.Error(e, $"Failed creating AzureDataManager for {identifier}");
             return null;
         }
     }
@@ -108,7 +108,7 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
         catch (Exception ex)
         {
             // This will likely fail during tests since DeveloperIdProvider uses ApplicationData.
-            _log.Warning("Failed setting DeveloperId change handler.", ex);
+            _log.Warning(ex, "Failed setting DeveloperId change handler.");
         }
 
         if (Instances.TryGetValue(InstanceName, out var instanceIdentifier))
@@ -670,7 +670,7 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
         }
         catch (Exception ex)
         {
-            _log.Error($"Failed Updating DataStore for: {parameters}", ex);
+            _log.Error(ex, $"Failed Updating DataStore for: {parameters}");
             tx.Rollback();
 
             // Rethrow so clients can catch/display an error UX.
@@ -801,7 +801,7 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
             }
             catch (Exception ex)
             {
-                _log.Error($"Failed setting Recreate Data Store setting.", ex);
+                _log.Error(ex, $"Failed setting Recreate Data Store setting.");
             }
         }
     }

--- a/src/AzureExtension/DataModel/DataObjects/Identity.cs
+++ b/src/AzureExtension/DataModel/DataObjects/Identity.cs
@@ -65,7 +65,7 @@ public class Identity
         }
         catch (Exception ex)
         {
-            Log.Warning($"Failed getting Avatar for {identity}.", ex);
+            Log.Warning(ex, $"Failed getting Avatar for {identity}.");
             return string.Empty;
         }
     }
@@ -90,7 +90,7 @@ public class Identity
         }
         catch (Exception ex)
         {
-            Log.Error($"Failed to deserialize Json object into Identity: {json}", ex);
+            Log.Error(ex, $"Failed to deserialize Json object into Identity: {json}");
             return null;
         }
     }

--- a/src/AzureExtension/DataModel/DataObjects/WorkItemType.cs
+++ b/src/AzureExtension/DataModel/DataObjects/WorkItemType.cs
@@ -82,7 +82,7 @@ public class WorkItemType
         }
         catch (Exception ex)
         {
-            Log.Error($"Failed to deserialize Json object into WorkItemType: {json}", ex);
+            Log.Error(ex, $"Failed to deserialize Json object into WorkItemType: {json}");
             return null;
         }
     }

--- a/src/AzureExtension/DataModel/DataStore.cs
+++ b/src/AzureExtension/DataModel/DataStore.cs
@@ -65,7 +65,7 @@ public class DataStore : IDisposable
                     // if we had a problem opening the DB and fetching the pragma, then
                     // we surely cannot reuse it.
                     deleteExistingDatabase = true;
-                    _log.Error($"Unable to open existing database to verify schema. Deleting database.", e);
+                    _log.Error(e, $"Unable to open existing database to verify schema. Deleting database.");
                 }
             }
 
@@ -91,18 +91,18 @@ public class DataStore : IDisposable
                 {
                     if ((uint)e.HResult == 0x80070020)
                     {
-                        _log.Error($"Sharing Violation Error; datastore exists and cannot be deleted ({DataStoreFilePath})", e);
+                        _log.Error(e, $"Sharing Violation Error; datastore exists and cannot be deleted ({DataStoreFilePath})");
                     }
                     else
                     {
-                        _log.Error($"I/O Error ({DataStoreFilePath})", e);
+                        _log.Error(e, $"I/O Error ({DataStoreFilePath})");
                     }
 
                     throw;
                 }
                 catch (UnauthorizedAccessException e)
                 {
-                    _log.Error($"Access Denied ({e})", e);
+                    _log.Error(e, $"Access Denied ({e})");
                     throw;
                 }
             }
@@ -127,7 +127,7 @@ public class DataStore : IDisposable
             }
             catch (Exception e)
             {
-                _log.Error($"Failed creating directory: ({directory})", e);
+                _log.Error(e, $"Failed creating directory: ({directory})");
                 throw;
             }
         }
@@ -166,7 +166,7 @@ public class DataStore : IDisposable
         }
         catch (SqliteException e)
         {
-            _log.Error($"Failed to open connection: {Connection.ConnectionString}", e);
+            _log.Error(e, $"Failed to open connection: {Connection.ConnectionString}");
         }
 
         _log.Debug($"Opened DataStore at {DataStoreFilePath}");
@@ -262,7 +262,7 @@ public class DataStore : IDisposable
         }
         catch (SqliteException e)
         {
-            _log.Error($"Failure executing SQL Command: {command.CommandText}", e);
+            _log.Error(e, $"Failure executing SQL Command: {command.CommandText}");
         }
     }
 

--- a/src/AzureExtension/DevBox/DevBoxInstance.cs
+++ b/src/AzureExtension/DevBox/DevBoxInstance.cs
@@ -120,7 +120,7 @@ public class DevBoxInstance : IComputeSystem
             }
             catch (Exception ex)
             {
-                _log.Error($"Error processing properties for {DisplayName}", ex);
+                _log.Error(ex, $"Error processing properties for {DisplayName}");
             }
         }
     }
@@ -185,7 +185,7 @@ public class DevBoxInstance : IComputeSystem
             catch (Exception ex)
             {
                 UpdateStateForUI();
-                _log.Error($"Unable to procress DevBox operation '{nameof(DevBoxOperation)}'", ex);
+                _log.Error(ex, $"Unable to procress DevBox operation '{nameof(DevBoxOperation)}'");
                 return new ComputeSystemOperationResult(ex, Resources.GetResource(Constants.DevBoxUnableToPerformOperationKey, ex.Message), ex.Message);
             }
         }).AsAsyncOperation();
@@ -278,7 +278,7 @@ public class DevBoxInstance : IComputeSystem
             }
             catch (Exception ex)
             {
-                _log.Error($"Error setting state after the long running operation completed successfully", ex);
+                _log.Error(ex, $"Error setting state after the long running operation completed successfully");
                 DevBoxState.ProvisioningState = Constants.DevBoxProvisioningStates.Failed;
                 DevBoxState.PowerState = Constants.DevBoxPowerStates.Unknown;
                 RemoveOperationInProgressFlag();
@@ -429,7 +429,7 @@ public class DevBoxInstance : IComputeSystem
             }
             catch (Exception ex)
             {
-                _log.Error($"Error connecting to {DisplayName}", ex);
+                _log.Error(ex, $"Error connecting to {DisplayName}");
                 return new ComputeSystemOperationResult(ex, Resources.GetResource(Constants.DevBoxUnableToPerformOperationKey, ex.Message), string.Empty);
             }
         }).AsAsyncOperation();
@@ -470,7 +470,7 @@ public class DevBoxInstance : IComputeSystem
             }
             catch (Exception ex)
             {
-                _log.Error($"Error getting thumbnail for {DisplayName}", ex);
+                _log.Error(ex, $"Error getting thumbnail for {DisplayName}");
                 return new ComputeSystemThumbnailResult(ex, Resources.GetResource(Constants.DevBoxUnableToPerformOperationKey, ex.Message), ex.Message);
             }
         }).AsAsyncOperation();

--- a/src/AzureExtension/DevBox/DevBoxProvider.cs
+++ b/src/AzureExtension/DevBox/DevBoxProvider.cs
@@ -113,7 +113,7 @@ public class DevBoxProvider : IComputeSystemProvider
                 }
                 catch (Exception ex)
                 {
-                    _log.Error($"Error processing project {project.Name}", ex);
+                    _log.Error(ex, $"Error processing project {project.Name}");
                 }
             }
         }

--- a/src/AzureExtension/Helpers/AzureRepositoryHierarchy.cs
+++ b/src/AzureExtension/Helpers/AzureRepositoryHierarchy.cs
@@ -157,7 +157,7 @@ public class AzureRepositoryHierarchy
         }
         catch (Exception e)
         {
-            Log.Error(e.Message, e);
+            Log.Error(e, e.Message);
         }
 
         return new List<TeamProjectReference>();

--- a/src/AzureExtension/Helpers/Resources.cs
+++ b/src/AzureExtension/Helpers/Resources.cs
@@ -24,7 +24,7 @@ public static class Resources
         }
         catch (Exception ex)
         {
-            log?.Error($"Failed loading resource: {identifier}", ex);
+            log?.Error(ex, $"Failed loading resource: {identifier}");
 
             // If we fail, load the original identifier so it is obvious which resource is missing.
             return identifier;

--- a/src/AzureExtension/Notifications/NotificationHandler.cs
+++ b/src/AzureExtension/Notifications/NotificationHandler.cs
@@ -41,7 +41,7 @@ public class NotificationHandler
             }
             catch (Exception ex)
             {
-                Log.Error($"Failed launching Uri for {args.Arguments["htmlurl"]}", ex);
+                Log.Error(ex, $"Failed launching Uri for {args.Arguments["htmlurl"]}");
             }
 
             return;

--- a/src/AzureExtension/Providers/RepositoryProvider.cs
+++ b/src/AzureExtension/Providers/RepositoryProvider.cs
@@ -187,7 +187,7 @@ public class RepositoryProvider : IRepositoryProvider2
             }
             catch (Exception e)
             {
-                _log.Error(e.Message, e);
+                _log.Error(e, e.Message);
                 return new RepositoriesResult(e, e.Message);
             }
         }).AsAsyncOperation();
@@ -332,27 +332,27 @@ public class RepositoryProvider : IRepositoryProvider2
             }
             catch (LibGit2Sharp.RecurseSubmodulesException recurseException)
             {
-                _log.Error("Could not clone all sub modules", recurseException);
+                _log.Error(recurseException, "Could not clone all sub modules");
                 return new ProviderOperationResult(ProviderOperationStatus.Failure, recurseException, "Could not clone all modules", recurseException.Message);
             }
             catch (LibGit2Sharp.UserCancelledException userCancelledException)
             {
-                _log.Error("The user stopped the clone operation", userCancelledException);
+                _log.Error(userCancelledException, "The user stopped the clone operation");
                 return new ProviderOperationResult(ProviderOperationStatus.Failure, userCancelledException, "User cancelled the operation", userCancelledException.Message);
             }
             catch (LibGit2Sharp.NameConflictException nameConflictException)
             {
-                _log.Error(nameConflictException.Message, nameConflictException);
+                _log.Error(nameConflictException, nameConflictException.Message);
                 return new ProviderOperationResult(ProviderOperationStatus.Failure, nameConflictException, "The location exists and is non-empty", nameConflictException.Message);
             }
             catch (LibGit2Sharp.LibGit2SharpException libGitTwoException)
             {
-                _log.Error($"Either no logged in account has access to this repo, or the repo can't be found", libGitTwoException);
+                _log.Error(libGitTwoException, $"Either no logged in account has access to this repo, or the repo can't be found");
                 return new ProviderOperationResult(ProviderOperationStatus.Failure, libGitTwoException, "LigGit2 threw an exception", "LibGit2 Threw an exception");
             }
             catch (Exception e)
             {
-                _log.Error("Could not clone the repository", e);
+                _log.Error(e, "Could not clone the repository");
                 return new ProviderOperationResult(ProviderOperationStatus.Failure, e, "Something happened when cloning the repo", "something happened when cloning the repo");
             }
 
@@ -459,7 +459,7 @@ public class RepositoryProvider : IRepositoryProvider2
             }
             catch (Exception e)
             {
-                _log.Error(e.Message, e);
+                _log.Error(e, e.Message);
             }
         });
 

--- a/src/AzureExtension/Services/DevBox/DevBoxCreationManager.cs
+++ b/src/AzureExtension/Services/DevBox/DevBoxCreationManager.cs
@@ -75,7 +75,7 @@ public class DevBoxCreationManager : IDevBoxCreationManager
         }
         catch (Exception ex)
         {
-            _log.Error($"unable to create the Dev Box with user options: {parameters}", ex);
+            _log.Error(ex, $"unable to create the Dev Box with user options: {parameters}");
             return new CreateComputeSystemResult(ex, Resources.GetResource(CreationErrorProgressKey, parameters.DevBoxName, parameters.ProjectName), ex.Message);
         }
     }

--- a/src/AzureExtension/Services/DevBox/DevBoxManagementService.cs
+++ b/src/AzureExtension/Services/DevBox/DevBoxManagementService.cs
@@ -62,7 +62,7 @@ public class DevBoxManagementService : IDevBoxManagementService
         }
         catch (Exception ex)
         {
-            _log.Error($"DevBoxHttpRequest failed: Exception", ex);
+            _log.Error(ex, $"DevBoxHttpRequest failed: Exception");
             throw;
         }
     }
@@ -88,7 +88,7 @@ public class DevBoxManagementService : IDevBoxManagementService
             catch (Exception ex)
             {
                 projectJson.TryGetProperty("name", out var projectWithErrorName);
-                _log.Error($"unable to get pools for {projectWithErrorName}", ex);
+                _log.Error(ex, $"unable to get pools for {projectWithErrorName}");
             }
         }
 

--- a/src/AzureExtension/Services/DevBox/DevBoxOperationWatcher.cs
+++ b/src/AzureExtension/Services/DevBox/DevBoxOperationWatcher.cs
@@ -95,7 +95,7 @@ public class DevBoxOperationWatcher : IDevBoxOperationWatcher
                 }
                 catch (Exception ex)
                 {
-                    _log.Error($"Dev Box operation monitoring stopped unexpectedly. Uri: {operationUri}, Id: {operationId}", ex);
+                    _log.Error(ex, $"Dev Box operation monitoring stopped unexpectedly. Uri: {operationUri}, Id: {operationId}");
 
                     completionCallback(DevCenterOperationStatus.Failed);
                     RemoveTimer(operationId);
@@ -150,7 +150,7 @@ public class DevBoxOperationWatcher : IDevBoxOperationWatcher
                 }
                 catch (Exception ex)
                 {
-                    _log.Error($"Dev Box provisioning monitoring stopped unexpectedly.", ex);
+                    _log.Error(ex, $"Dev Box provisioning monitoring stopped unexpectedly.");
                     devBoxInstance.ProvisioningMonitorCompleted(null, ProvisioningStatus.Failed);
                     completionCallback(devBoxInstance);
                     RemoveTimer(devBoxId);

--- a/src/AzureExtension/Widgets/AzurePullRequestsWidget.cs
+++ b/src/AzureExtension/Widgets/AzurePullRequestsWidget.cs
@@ -191,7 +191,7 @@ internal sealed class AzurePullRequestsWidget : AzureWidget
         }
         catch (Exception ex)
         {
-            Log.Error("Failed requesting data update.", ex);
+            Log.Error(ex, "Failed requesting data update.");
         }
     }
 
@@ -316,7 +316,7 @@ internal sealed class AzurePullRequestsWidget : AzureWidget
         }
         catch (Exception e)
         {
-            Log.Error("Error retrieving data.", e);
+            Log.Error(e, "Error retrieving data.");
             DataState = WidgetDataState.Failed;
             return;
         }

--- a/src/AzureExtension/Widgets/AzureQueryListWidget.cs
+++ b/src/AzureExtension/Widgets/AzureQueryListWidget.cs
@@ -198,7 +198,7 @@ internal sealed class AzureQueryListWidget : AzureWidget
         }
         catch (Exception ex)
         {
-            Log.Error("Failed requesting data update.", ex);
+            Log.Error(ex, "Failed requesting data update.");
         }
     }
 
@@ -329,7 +329,7 @@ internal sealed class AzureQueryListWidget : AzureWidget
         }
         catch (Exception e)
         {
-            Log.Error("Error retrieving data.", e);
+            Log.Error(e, "Error retrieving data.");
             DataState = WidgetDataState.Failed;
             return;
         }

--- a/src/AzureExtension/Widgets/AzureQueryTilesWidget.cs
+++ b/src/AzureExtension/Widgets/AzureQueryTilesWidget.cs
@@ -220,7 +220,7 @@ internal sealed class AzureQueryTilesWidget : AzureWidget
         }
         catch (Exception ex)
         {
-            Log.Error("Failed requesting data update.", ex);
+            Log.Error(ex, "Failed requesting data update.");
         }
 
         Log.Debug($"Requested data update for this widget.");
@@ -282,7 +282,7 @@ internal sealed class AzureQueryTilesWidget : AzureWidget
                     }
                     catch (Exception ex)
                     {
-                        Log.Error($"Failed getting query info or creating the tile object.", ex);
+                        Log.Error(ex, $"Failed getting query info or creating the tile object.");
                         return;
                     }
                 }

--- a/src/AzureExtension/Widgets/AzureWidget.cs
+++ b/src/AzureExtension/Widgets/AzureWidget.cs
@@ -340,7 +340,7 @@ public abstract class AzureWidget : WidgetImpl
         }
         catch (Exception e)
         {
-            Log.Error("Error getting template.", e);
+            Log.Error(e, "Error getting template.");
             return string.Empty;
         }
     }
@@ -479,7 +479,7 @@ public abstract class AzureWidget : WidgetImpl
         }
         catch (Exception ex)
         {
-            Log.Error("Failed Requesting Update", ex);
+            Log.Error(ex, "Failed Requesting Update");
         }
 
         lastUpdateRequest = DateTime.Now;
@@ -519,7 +519,7 @@ public abstract class AzureWidget : WidgetImpl
             }
             catch (Exception ex)
             {
-                Log.Error($"Failed getting DeveloperId state.", ex);
+                Log.Error(ex, $"Failed getting DeveloperId state.");
             }
         }
 

--- a/src/AzureExtension/Widgets/WidgetProvider.cs
+++ b/src/AzureExtension/Widgets/WidgetProvider.cs
@@ -58,7 +58,7 @@ public sealed class WidgetProvider : IWidgetProvider, IWidgetProvider2
         }
         catch (Exception e)
         {
-            _log.Error("Failed retrieving list of running widgets.", e);
+            _log.Error(e, "Failed retrieving list of running widgets.");
             return;
         }
 

--- a/src/AzureExtensionServer/Program.cs
+++ b/src/AzureExtensionServer/Program.cs
@@ -184,7 +184,7 @@ public sealed class Program
         }
         catch (Exception ex)
         {
-            Log.Information("Failed getting package information.", ex);
+            Log.Information(ex, "Failed getting package information.");
         }
     }
 
@@ -219,7 +219,7 @@ public sealed class Program
         }
         catch (Exception ex)
         {
-            Log.Error("Failed attempting to verify or perform database recreation.", ex);
+            Log.Error(ex, "Failed attempting to verify or perform database recreation.");
         }
     }
 


### PR DESCRIPTION
## Summary of the pull request
This fixes the ordering of exception logging such that exceptions will be properly logged.

## References and relevant issues
Closes #148

## Detailed description of the pull request / Additional comments
Serilog has multiple valid logging signatures, but the only one that logs exceptions is if the exception is the first argument. Exceptions can be placed validly as 2nd, 3rd, etc. arguments after a string but those are assumed to be part of the message template and otherwise ignored. This resulted in valid log messages but exceptions that were intended to be logged were not being logged.

* Fixed all Error, Warning, Debug, and Information logging that included an exception at the end of the message and move dit to the front of the message so it would be logged instead of swallowed.

## Validation steps performed
* Build validation

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
