### PR TITLE
Add adaptive card UI for Dev Box

### DIFF
--- a/src/AzureExtension/AzureExtension.csproj
+++ b/src/AzureExtension/AzureExtension.csproj
@@ -45,6 +45,12 @@
     <Content Include="Widgets\Templates\AzureSignInTemplate.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="DevBox\Templates\CreationForm.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="DevBox\Templates\ReviewForm.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>
@@ -58,7 +64,7 @@
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.206-beta" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
-    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.300.443" />
+    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.400.460" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.205.1" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.205.1" />

--- a/src/AzureExtension/Contracts/IDevBoxManagementService.cs
+++ b/src/AzureExtension/Contracts/IDevBoxManagementService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
+using AzureExtension.DevBox.DevBoxJsonToCsClasses;
 using AzureExtension.DevBox.Models;
 using Microsoft.Windows.DevHome.SDK;
 
@@ -32,10 +33,10 @@ public interface IDevBoxManagementService
     /// <summary>
     /// Generates a list of objects that each contain a Dev Center project and the Dev Box pools associated with that project.
     /// </summary>
-    /// <param name="projectsJson">The Json recieved from a rest api that returns a list of Dev Center projects.</param>
+    /// <param name="projects">The Deserialized Json recieved from a rest api that returns a list of Dev Center projects.</param>
     /// <param name="developerId">The DeveloperId associated with the request.</param>
     /// <returns>A list of objects where each contain a project and its associated pools.</returns>
-    public Task<List<DevBoxProjectAndPoolContainer>> GetAllProjectsToPoolsMappingAsync(JsonElement projectsJson, IDeveloperId developerId);
+    public Task<List<DevBoxProjectAndPoolContainer>> GetAllProjectsToPoolsMappingAsync(DevBoxProjects projects, IDeveloperId developerId);
 
     /// <summary>
     /// Initiates a call to create a Dev Box in the Dev Center.

--- a/src/AzureExtension/DevBox/Constants.cs
+++ b/src/AzureExtension/DevBox/Constants.cs
@@ -76,7 +76,7 @@ public static class Constants
 
     public static readonly TimeSpan OneMinutePeriod = TimeSpan.FromMinutes(1);
 
-    public static readonly TimeSpan FiveMinutePeriod = TimeSpan.FromMinutes(5);
+    public static readonly TimeSpan ThreeMinutePeriod = TimeSpan.FromMinutes(3);
 
     public static readonly TimeSpan OperationDeadline = TimeSpan.FromHours(2);
 

--- a/src/AzureExtension/DevBox/Constants.cs
+++ b/src/AzureExtension/DevBox/Constants.cs
@@ -109,6 +109,8 @@ public static class Constants
         public const string Deleting = "Deleting";
 
         public const string Updating = "Updating";
+
+        public const string Deleted = "Deleted";
     }
 
     public static class DevBoxActionStates

--- a/src/AzureExtension/DevBox/DevBoxInstance.cs
+++ b/src/AzureExtension/DevBox/DevBoxInstance.cs
@@ -201,7 +201,7 @@ public class DevBoxInstance : IComputeSystem, IComputeSystem2
         {
             return ComputeSystemOperations.None;
         }
-        
+
         ComputeSystemOperations operations = ComputeSystemOperations.Start | ComputeSystemOperations.ShutDown | ComputeSystemOperations.Delete |
             ComputeSystemOperations.Restart | ComputeSystemOperations.ApplyConfiguration;
 

--- a/src/AzureExtension/DevBox/Models/CreateComputeSystemOperation.cs
+++ b/src/AzureExtension/DevBox/Models/CreateComputeSystemOperation.cs
@@ -5,6 +5,7 @@ using AzureExtension.Contracts;
 using AzureExtension.DevBox.Exceptions;
 using DevHomeAzureExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
+using Serilog;
 using Windows.Foundation;
 
 namespace AzureExtension.DevBox.Models;
@@ -16,6 +17,8 @@ public delegate CreateComputeSystemOperation CreateComputeSystemOperationFactory
 /// </summary>
 public class CreateComputeSystemOperation : ICreateComputeSystemOperation
 {
+    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(CreateComputeSystemOperation));
+
     private CreateComputeSystemResult? _result;
 
     private const string OperationInProgressMessageKey = "DevBox_CreationOperationAlreadyInProgress";
@@ -60,6 +63,7 @@ public class CreateComputeSystemOperation : ICreateComputeSystemOperation
                     if (IsOperationInProgress)
                     {
                         var exception = new DevBoxCreationException("Operation already in progress");
+                        _log.Error(exception, exception.Message);
                         return new CreateComputeSystemResult(exception, Resources.GetResource(OperationInProgressMessageKey), exception.Message);
                     }
                     else if (IsCompleted)
@@ -77,6 +81,7 @@ public class CreateComputeSystemOperation : ICreateComputeSystemOperation
             }
             catch (Exception ex)
             {
+                _log.Error(ex, "unable to start the Dev Box creation process");
                 _result = new CreateComputeSystemResult(ex, Resources.GetResource(OperationCompletedMessageKey), ex.Message);
             }
 

--- a/src/AzureExtension/DevBox/Models/CreationAdaptiveCardSession.cs
+++ b/src/AzureExtension/DevBox/Models/CreationAdaptiveCardSession.cs
@@ -1,0 +1,401 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using DevHomeAzureExtension.Helpers;
+using Microsoft.Windows.DevHome.SDK;
+using Serilog;
+using Windows.Foundation;
+
+namespace AzureExtension.DevBox.Models;
+
+public enum SessionState
+{
+    InitialCreationForm,
+    ReviewForm,
+}
+
+/// <summary>
+/// Represents an adaptive card session that is presented to the user in Dev Homes environment creation UI. It is in charge
+/// of retrieving and updating the adaptive card based on user input and interaction.
+/// </summary>
+public class CreationAdaptiveCardSession : IExtensionAdaptiveCardSession2
+{
+    private readonly Serilog.ILogger _log = Log.ForContext("SourceContext", nameof(CreationAdaptiveCardSession));
+
+    private readonly string _pathToCreationFormTemplate = Path.Combine(AppContext.BaseDirectory, @"AzureExtension\DevBox\Templates\", "CreationForm.json");
+
+    private readonly string _pathToReviewFormTemplate = Path.Combine(AppContext.BaseDirectory, @"AzureExtension\DevBox\Templates\", "ReviewForm.json");
+
+    private readonly string _adaptiveCardNextButtonId = "DevHomeMachineConfigurationNextButton";
+
+    /// <summary>
+    /// An object that contains projects and a list of pools for that project
+    /// </summary>
+    private readonly List<DevBoxProjectAndPoolContainer> _devBoxProjectAndPoolContainer;
+
+    private readonly List<JsonArray> _listOfAllDevBoxPools = new();
+
+    private readonly JsonArray _arrayOfProjects = new();
+
+    private readonly Dictionary<string, List<string>> _invalidDevBoxNames = new();
+
+    private int _currentSelectedProjectIndex;
+
+    private int _currentSelectedPoolIndex;
+
+    private string _currentTextBoxValue = string.Empty;
+
+    private ProviderOperationResult _operationResult = new(ProviderOperationStatus.Success, null, string.Empty, string.Empty);
+
+    private bool _shouldEndSession;
+
+    /// <summary>
+    /// Gets the Json string that represents the user input that was passed to the adaptive card session. We'll keep this so we can pass it back to Dev Home
+    /// at the end of the session.
+    /// </summary>
+    private Dictionary<string, string> _originalUserInputJson = new();
+
+    public event TypedEventHandler<IExtensionAdaptiveCardSession2, ExtensionAdaptiveCardSessionStoppedEventArgs>? Stopped;
+
+    public void Dispose()
+    {
+    }
+
+    public CreationAdaptiveCardSession(List<DevBoxProjectAndPoolContainer> containers, IEnumerable<IComputeSystem>? devBoxes)
+    {
+        _devBoxProjectAndPoolContainer = containers;
+        BuildUsedDevBoxNamesPerProject(devBoxes);
+        BuildAllProjectsAndPoolJsonObjects();
+    }
+
+    private IExtensionAdaptiveCard? _creationAdaptiveCard;
+
+    public bool ShouldEndSession { get; private set; }
+
+    public ProviderOperationResult Initialize(IExtensionAdaptiveCard extensionUI)
+    {
+        _creationAdaptiveCard = extensionUI;
+
+        return GetCreationFormAdaptiveCard(string.Empty, _currentSelectedProjectIndex, _currentSelectedPoolIndex);
+    }
+
+    public IAsyncOperation<ProviderOperationResult> OnAction(string action, string inputs)
+    {
+        return Task.Run(() =>
+        {
+            try
+            {
+                var actionPayLoad = JsonSerializer.Deserialize<Dictionary<string, string>>(action);
+                var inputPayLoad = JsonSerializer.Deserialize<Dictionary<string, string>>(inputs);
+
+                switch (_creationAdaptiveCard?.State)
+                {
+                    case "initialCreationForm":
+                        HandleActionWhenFormInInitialState(actionPayLoad!, inputPayLoad!);
+                        break;
+                    case "reviewForm":
+                        HandleActionWhenFormInReviewState(actionPayLoad!);
+                        break;
+                    default:
+                        _shouldEndSession = true;
+                        _operationResult = new ProviderOperationResult(
+                            ProviderOperationStatus.Failure,
+                            new InvalidOperationException(nameof(action)),
+                            Resources.GetResource("AdaptiveCardStateNotRecognizedError"),
+                            $"Unexpected state:{_creationAdaptiveCard?.State}");
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "Unable to update the adaptive card session for creation");
+                _shouldEndSession = true;
+                _operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, ex, ex.Message, ex.Message);
+            }
+
+            if (_shouldEndSession)
+            {
+                // The session has now ended. We'll raise the Stopped event to notify anyone in Dev Home who was listening to this event,
+                // that the session has ended.
+                Stopped?.Invoke(
+                    this,
+                    new ExtensionAdaptiveCardSessionStoppedEventArgs(_operationResult, GetDataToCreateDevBox()));
+            }
+
+            return _operationResult;
+        }).AsAsyncOperation();
+    }
+
+    /// <summary>
+    /// Loads the adaptive card template based on the session state.
+    /// </summary>
+    /// <param name="state">State the adaptive card session</param>
+    /// <returns>A Json string representing the adaptive card</returns>
+    public string LoadTemplate(SessionState state)
+    {
+        var pathToTemplate = state switch
+        {
+            SessionState.InitialCreationForm => _pathToCreationFormTemplate,
+            SessionState.ReviewForm => _pathToReviewFormTemplate,
+            _ => _pathToCreationFormTemplate,
+        };
+
+        return File.ReadAllText(pathToTemplate, Encoding.Default);
+    }
+
+    /// <summary>
+    /// Creates the initial form that will be displayed to the user.
+    /// </summary>
+    /// <remarks>
+    /// This will initially show a textbox, a combo box with a list of projects and a button to refresh the users pools.
+    /// When the user selects a project the pools are not shown by default. Once they click the view pools button it submits
+    /// the adaptive card and we send back a new adaptive card that contains a new combo box with the list of pools.
+    /// </remarks>
+    /// <param name="textboxText">The text currently in the textbox. This is used so we can save input from the previous adaptive card when refreshing the adaptive card</param>
+    /// <param name="selectedProjectIndex">The current index of the selected project in the projects combo box. This is used so we can save input from the previous adaptive card when refreshing the adaptive card</param>
+    /// <param name="selectedPoolIndex">The current index of the selected pool in the pools combo box. This is used so we can save input from the previous adaptive card when refreshing the adaptive card</param>
+    /// <returns>Result of the operation</returns>
+    private ProviderOperationResult GetCreationFormAdaptiveCard(string textboxText, int selectedProjectIndex, int selectedPoolIndex)
+    {
+        try
+        {
+            _log.Information("Building creation card with the following parameters: +" +
+                $"'{nameof(textboxText)}': {textboxText}, " +
+                $"'{nameof(selectedProjectIndex)}': {selectedProjectIndex}, " +
+                $"'{nameof(selectedPoolIndex)}': {selectedPoolIndex}");
+
+            var primaryButtonForCreationFlowText = Resources.GetResource("DevBox_PrimaryButtonLabelForCreationFlow");
+            var secondaryButtonForCreationFlowText = Resources.GetResource("DevBox_SecondaryButtonLabelForCreationFlow");
+            var settingsCardLabel = Resources.GetResource("DevBox_SettingsCardLabel");
+            var enterNewEnvironmentNameLabel = Resources.GetResource("DevBox_EnterNewEnvironmentTextBoxLabel");
+            var projectComboBoxLabel = Resources.GetResource("DevBox_ProjectComboBoxLabel");
+            var poolComboBoxLabel = Resources.GetResource("DevBox_PoolComboBoxLabel");
+            var getPoolsButtonLabel = Resources.GetResource("DevBox_PoolsButtonLabel");
+            var devBoxTextBoxErrorMessage = Resources.GetResource("DevBox_TextBoxErrorMessage");
+            var devBoxProjectComboBoxErrorMessage = Resources.GetResource("DevBox_ProjectComboBoxErrorMessage");
+            var devBoxPoolsComboBoxErrorMessage = Resources.GetResource("DevBox_PoolsComboBoxErrorMessage");
+            var devBoxPoolComboBoxLabel = Resources.GetResource("DevBox_PoolComboBoxLabel");
+            var devBoxPoolsPlaceHolder = Resources.GetResource("DevBox_PoolsPlaceHolder");
+
+            _arrayOfProjects![_currentSelectedProjectIndex]!.AsObject().TryGetPropertyValue("title", out var projectName);
+
+            var templateData =
+                $"{{\"PrimaryButtonLabelForCreationFlow\" : \"{primaryButtonForCreationFlowText}\"," +
+                $"\"SecondaryButtonLabelForCreationFlow\" : \"{secondaryButtonForCreationFlowText}\"," +
+                $"\"EnterNewEnvironmentTextBoxLabel\": \"{enterNewEnvironmentNameLabel}\"," +
+                $"\"ProjectComboBoxLabel\": \"{projectComboBoxLabel}\"," +
+                $"\"PoolComboBoxLabel\": \"{poolComboBoxLabel}\"," +
+                $"\"PoolsButtonLabel\": \"{getPoolsButtonLabel}\"," +
+                $"\"DevBoxTextBoxErrorMessage\": \"{devBoxTextBoxErrorMessage}\"," +
+                $"\"DevBoxProjectComboBoxErrorMessage\": \"{devBoxProjectComboBoxErrorMessage}\"," +
+                $"\"DevBoxPoolsComboBoxErrorMessage\": \"{devBoxPoolsComboBoxErrorMessage}\"," +
+                $"\"DevBoxPoolComboBoxLabel\": \"{devBoxPoolComboBoxLabel}\"," +
+                $"\"TextBoxText\": \"{textboxText}\"," +
+                $"\"DevBoxPoolsPlaceHolder\": \"{devBoxPoolsPlaceHolder}\"," +
+                $"\"SelectedProjectIndex\": \"{selectedProjectIndex}\"," +
+                $"\"SelectedPoolIndex\": \"{selectedPoolIndex}\"," +
+                $"\"DevBoxNameRegex\": \"{Constants.NameRegexPattern}\"," +
+                $"\"SelectionChangedDataForChildChoiceSet\": {JsonSerializer.Serialize(_listOfAllDevBoxPools)}," +
+                $"\"ProjectList\" : {_arrayOfProjects.ToJsonString()}," +
+                $"\"PoolsList\" : {_listOfAllDevBoxPools[selectedProjectIndex].ToJsonString()}" +
+                $"}}";
+
+            var template = LoadTemplate(SessionState.InitialCreationForm);
+
+            return _creationAdaptiveCard!.Update(template, templateData, "initialCreationForm");
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Unable to get get creation template and data");
+            var creationFormGenerationError = Resources.GetResource("DevBox_InitialCreationFormGenerationFailedError");
+            return new ProviderOperationResult(ProviderOperationStatus.Failure, ex, creationFormGenerationError, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Creates the review form that will be displayed to the user. This will be an adaptive card that is displayed in Dev Homes
+    /// setup flow review page.
+    /// </summary>
+    /// <returns>Result of the operation</returns>
+    private ProviderOperationResult GetForReviewFormAdaptiveCardAsync()
+    {
+        try
+        {
+            _log.Information("Building adaptive card template and data for the review form");
+
+            var container = _devBoxProjectAndPoolContainer[_currentSelectedProjectIndex];
+            var pool = container.Pools!.Value![_currentSelectedPoolIndex];
+
+            _log.Information($"New DevBox name: {_originalUserInputJson["NewEnvironmentName"]}" +
+                $"Project name: {container.Project!.Name}, Project index '{_currentSelectedProjectIndex}'" +
+                $"Pool Name: {pool.Name}, Pool index '{_currentSelectedPoolIndex}'");
+
+            // Setup localized strings for review form
+            var reviewPageNameLabel = Resources.GetResource("DevBox_ReviewPageNameLabel", ":");
+            var reviewPageProjectNameLabel = Resources.GetResource("DevBox_ReviewPageProjectNameLabel", ":");
+            var reviewPagePoolNameLabel = Resources.GetResource("DevBox_ReviewPagePoolNameLabel", ":");
+            var primaryButtonForCreationFlowText = Resources.GetResource("PrimaryButtonLabelForCreationFlow");
+            var secondaryButtonForCreationFlowText = Resources.GetResource("SecondaryButtonLabelForCreationFlow");
+            var poolHardwareSpecs = Resources.GetResource("DevBox_PoolSubtitle", pool.HardwareProfile.VCPUs, pool.HardwareProfile.MemoryGB, pool.StorageProfile.OsDisk.DiskSizeGB);
+
+            var reviewFormData = new JsonObject
+            {
+                { "NewEnvironmentName", _originalUserInputJson["NewEnvironmentName"] },
+                { "SelectedProjectName", container.Project!.Name },
+                { "SelectedPoolName", pool.Name },
+                { "ReviewPageProjectNameLabel", reviewPageProjectNameLabel },
+                { "ReviewPagePoolNameLabel", reviewPagePoolNameLabel },
+                { "ReviewPageSelectedPoolSpecs", poolHardwareSpecs },
+                { "ReviewPageNameLabel", reviewPageNameLabel },
+                { "PrimaryButtonLabelForCreationFlow", primaryButtonForCreationFlowText },
+                { "SecondaryButtonLabelForCreationFlow", secondaryButtonForCreationFlowText },
+            };
+
+            var template = LoadTemplate(SessionState.ReviewForm);
+
+            return _creationAdaptiveCard!.Update(LoadTemplate(SessionState.ReviewForm), reviewFormData.ToJsonString(), "reviewForm");
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Unable to get get review template and data");
+            var reviewFormGenerationError = Resources.GetResource("DevBox_ReviewFormGenerationFailedError");
+            return new ProviderOperationResult(ProviderOperationStatus.Failure, ex, reviewFormGenerationError, ex.Message);
+        }
+    }
+
+    private void HandleActionWhenFormInInitialState(Dictionary<string, string> actionPayload, Dictionary<string, string> inputPayload)
+    {
+        if (inputPayload.TryGetValue("NewEnvironmentName", out var textBoxStr))
+        {
+            _currentTextBoxValue = textBoxStr;
+        }
+
+        // check if a project was selected and update the selected index if it was.
+        if (inputPayload.TryGetValue("ProjectsComboBox", out var projectIndexStr) && int.TryParse(projectIndexStr, out var projectIndex))
+        {
+            _currentSelectedProjectIndex = projectIndex;
+
+            // check if a pool was selected and update the selected index if it was.
+            if (inputPayload.TryGetValue("PoolsComboBox", out var poolIndexStr) && int.TryParse(poolIndexStr, out var poolIndex))
+            {
+                // If the project index changes, when GetCreationFormAdaptiveCard is called the list of pools will change. So, the previous
+                // index is no longer valid.
+                _currentSelectedPoolIndex = poolIndex;
+            }
+        }
+
+        _log.Information($"HandleActionWhenFormInInitialState retrieved inputPayload: +" +
+            $"{nameof(_currentTextBoxValue)}: {_currentTextBoxValue}" +
+            $"{nameof(_currentSelectedProjectIndex)}: {_currentSelectedProjectIndex}" +
+            $"{nameof(_currentSelectedPoolIndex)}: {_currentSelectedPoolIndex}");
+
+        actionPayload.TryGetValue("id", out var actionButtonId);
+        if ((actionButtonId != null) && actionButtonId.Equals(_adaptiveCardNextButtonId, StringComparison.OrdinalIgnoreCase))
+        {
+            _log.Information("Dev Home is moving to the Review page. Sending the review form and saving the current user inputPayload");
+
+            // if OnAction's state is initialCreationForm and the user clicks the next button in Dev Home then the form was validated and they were able to
+            // enter a name for their DevBox, select a project, and select a ComboBox.
+            _originalUserInputJson = inputPayload;
+            _operationResult = GetForReviewFormAdaptiveCardAsync();
+        }
+    }
+
+    private void HandleActionWhenFormInReviewState(Dictionary<string, string> actionPayload)
+    {
+        actionPayload.TryGetValue("id", out var actionButtonId);
+
+        if ((actionButtonId != null) && actionButtonId.Equals(_adaptiveCardNextButtonId, StringComparison.OrdinalIgnoreCase))
+        {
+            _log.Information("Dev Home is moving to summary page.  Sending the review form");
+
+            // if OnAction's state is reviewForm, then the user has reviewed the form and Dev Home has started the creation process.
+            // we'll show the same form to the user in Dev Homes summary page.
+            _shouldEndSession = true;
+            _operationResult = GetForReviewFormAdaptiveCardAsync();
+        }
+        else
+        {
+            _log.Information("Dev Home is moving back to the configure environment creation page.  Sending the creatin form with");
+
+            // User is going back to creation form by clicking the previous button in Dev Homes review page.
+            _operationResult = GetCreationFormAdaptiveCard(_currentTextBoxValue, _currentSelectedProjectIndex, _currentSelectedPoolIndex);
+        }
+    }
+
+    private void BuildAllProjectsAndPoolJsonObjects()
+    {
+        _log.Information("Building json object for projects and pools");
+
+        for (var i = 0; i < _devBoxProjectAndPoolContainer.Count; i++)
+        {
+            var container = _devBoxProjectAndPoolContainer[i];
+            if (container?.Pools?.Value == null)
+            {
+                continue;
+            }
+
+            // Add information for the specific project to the project array
+            var projectInfo = new JsonObject
+                {
+                    { "title", container.Project!.Name },
+                    { "value", $"{i}" },
+                };
+
+            _arrayOfProjects.Add(projectInfo);
+
+            // Add all the pools for the project into a list that contains all pools.
+            // The index of the list will be directly related to the index of the project
+            // in the project array above.
+            var poolsArray = new JsonArray();
+            for (var k = 0; k < container.Pools.Value.Count; k++)
+            {
+                var pool = container.Pools.Value[k];
+                var poolHardwareSpecs = Resources.GetResource("DevBox_PoolSubtitle", pool.HardwareProfile.VCPUs, pool.HardwareProfile.MemoryGB, pool.StorageProfile.OsDisk.DiskSizeGB);
+                var poolInfo = new JsonObject
+                    {
+                        { "title", $"{pool.Name}" },
+                        { "subtitle", $"{poolHardwareSpecs}" },
+                        { "value", $"{k}" },
+                    };
+
+                poolsArray.Add(poolInfo);
+            }
+
+            _listOfAllDevBoxPools.Add(poolsArray);
+        }
+    }
+
+    private void BuildUsedDevBoxNamesPerProject(IEnumerable<IComputeSystem>? devBoxes)
+    {
+        if (devBoxes == null)
+        {
+            return;
+        }
+
+        foreach (var devBox in devBoxes)
+        {
+            if (devBox is DevBoxInstance instance)
+            {
+                if (!_invalidDevBoxNames.TryGetValue(instance.DevBoxState.ProjectName, out var _))
+                {
+                    _invalidDevBoxNames[instance.DevBoxState.ProjectName] = new();
+                }
+
+                _invalidDevBoxNames[instance.DevBoxState.ProjectName].Add(instance.DevBoxState.Name);
+            }
+        }
+    }
+
+    private string GetDataToCreateDevBox()
+    {
+        var container = _devBoxProjectAndPoolContainer[_currentSelectedProjectIndex];
+        var pool = container.Pools!.Value![_currentSelectedPoolIndex];
+
+        var creationParameters = new DevBoxCreationParameters(container!.Project!.Name, pool.Name, _originalUserInputJson["NewEnvironmentName"], container.Project.Properties.DevCenterUri);
+        return JsonSerializer.Serialize(creationParameters, Constants.JsonOptions);
+    }
+}

--- a/src/AzureExtension/DevBox/Models/DevBoxCreationParameters.cs
+++ b/src/AzureExtension/DevBox/Models/DevBoxCreationParameters.cs
@@ -15,16 +15,24 @@ public class DevBoxCreationParameters
 
     public string PoolName { get; set; } = string.Empty;
 
-    public string DevBoxName { get; set; } = string.Empty;
+    public string NewEnvironmentName { get; set; } = string.Empty;
 
     public string DevCenterUri { get; set; } = string.Empty;
+
+    public DevBoxCreationParameters(string projectName, string poolName, string newEnvironmentName, string devCenterUri)
+    {
+        ProjectName = projectName;
+        PoolName = poolName;
+        NewEnvironmentName = newEnvironmentName;
+        DevCenterUri = devCenterUri;
+    }
 
     public override string ToString()
     {
         var builder = new StringBuilder();
         builder.AppendLine(CultureInfo.InvariantCulture, $"Project Name: {ProjectName} ");
         builder.AppendLine(CultureInfo.InvariantCulture, $"Pool Name: {PoolName} ");
-        builder.AppendLine(CultureInfo.InvariantCulture, $"DevBox Name: {DevBoxName} ");
+        builder.AppendLine(CultureInfo.InvariantCulture, $"DevBox Name: {NewEnvironmentName} ");
         builder.AppendLine(CultureInfo.InvariantCulture, $"DevCenter Uri: {DevCenterUri} ");
         return builder.ToString();
     }

--- a/src/AzureExtension/DevBox/Templates/CreationForm.json
+++ b/src/AzureExtension/DevBox/Templates/CreationForm.json
@@ -1,0 +1,109 @@
+{
+  "type": "AdaptiveCard",
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "ColumnSet",
+      "spacing": "large",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "Input.Text",
+              "id": "NewEnvironmentName",
+              "label": "${EnterNewEnvironmentTextBoxLabel}",
+              "maxLength": 100,
+              "isRequired": true,
+              "errorMessage": "${DevBoxTextBoxErrorMessage}",
+              "regex": "${DevBoxNameRegex}",
+              "spacing": "large",
+              "value": "${TextBoxText}"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ColumnSet",
+      "spacing": "large",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "stretch",
+          "items": [
+            {
+              "type": "Input.ChoiceSet",
+              "id": "ProjectsComboBox",
+              "label": "${ProjectComboBoxLabel}",
+              "devHomeChildChoiceSetId": "PoolsComboBox",
+              "devHomeSelectionChangedDataForChildChoiceSet": "${SelectionChangedDataForChildChoiceSet}",
+              "devHomeRefreshChildChoiceSetOnSelectionChanged": true,
+              "isRequired": true,
+              "errorMessage": "${DevBoxProjectComboBoxErrorMessage}",
+              "style": "compact",
+              "value": "${SelectedProjectIndex}",
+              "choices": [
+                {
+                  "$data": "${ProjectList}",
+                  "title": "${title}",
+                  "value": "${value}"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ColumnSet",
+      "spacing": "large",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "stretch",
+          "items": [
+
+            {
+              "type": "Input.ChoiceSet",
+              "id": "PoolsComboBox",
+              "devHomeParentChoiceSetId": "ProjectsComboBox",
+              "label": "${DevBoxPoolComboBoxLabel}",
+              "isRequired": true,
+              "errorMessage": "${DevBoxPoolsComboBoxErrorMessage}",
+              "placeholder": "${DevBoxPoolsPlaceHolder}",
+              "style": "compact",
+              "value": "${SelectedPoolIndex}",
+              "devHomeChoicesData": [
+                {
+                  "$data": "${PoolsList}",
+                  "title": "${title}",
+                  "subtitle": "${subtitle}",
+                  "value": "${value}"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ActionSet",
+      "id": "DevHomeTopLevelActionSet",
+      "actions": [
+        {
+          "id": "DevHomeMachineConfigurationNextButton",
+          "type": "Action.Submit",
+          "title": "${PrimaryButtonLabelForCreationFlow}"
+        },
+        {
+          "id": "DevHomeMachineConfigurationPreviousButton",
+          "type": "Action.Submit",
+          "title": "${SecondaryButtonLabelForCreationFlow}"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AzureExtension/DevBox/Templates/ReviewForm.json
+++ b/src/AzureExtension/DevBox/Templates/ReviewForm.json
@@ -1,0 +1,92 @@
+{
+  "type": "AdaptiveCard",
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.6",
+  "body": [
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "auto",
+          "spacing": "medium",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${ReviewPageNameLabel}",
+              "wrap": true,
+              "size": "medium"
+            },
+            {
+              "type": "TextBlock",
+              "text": "${NewEnvironmentName}",
+              "wrap": true,
+              "size": "medium"
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "spacing": "extraLarge",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${ReviewPageProjectNameLabel}",
+              "wrap": true,
+              "size": "medium"
+            },
+            {
+              "type": "TextBlock",
+              "text": "${SelectedProjectName}",
+              "wrap": true,
+              "size": "medium"
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "spacing": "extraLarge",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${ReviewPagePoolNameLabel}",
+              "wrap": true,
+              "size": "medium"
+            },
+            {
+              "type": "TextBlock",
+              "text": "${SelectedPoolName}",
+              "wrap": true,
+              "size": "medium"
+            },
+            {
+              "type": "TextBlock",
+              "text": "${ReviewPageSelectedPoolSpecs}",
+              "wrap": true,
+              "isSubtle": true,
+              "size": "medium"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ActionSet",
+      "id": "DevHomeTopLevelActionSet",
+      "actions": [
+        {
+          "id": "DevHomeMachineConfigurationNextButton",
+          "type": "Action.Submit",
+          "title": "${PrimaryButtonLabelForCreationFlow}"
+        },
+        {
+          "id": "DevHomeMachineConfigurationPreviousButton",
+          "type": "Action.Submit",
+          "title": "${SecondaryButtonLabelForCreationFlow}"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AzureExtension/Services/DevBox/DevBoxCreationManager.cs
+++ b/src/AzureExtension/Services/DevBox/DevBoxCreationManager.cs
@@ -9,6 +9,7 @@ using AzureExtension.DevBox.Models;
 using DevHomeAzureExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 
 namespace AzureExtension.Services.DevBox;
 
@@ -48,23 +49,24 @@ public class DevBoxCreationManager : IDevBoxCreationManager
     {
         try
         {
+            _log.Information($"Starting the create DevBox operation for new environment with new: {parameters.NewEnvironmentName}");
             operation.UpdateProgress(Resources.GetResource(SendingCreationRequestProgressKey), Constants.IndefiniteProgress);
 
             var result = await _devBoxManagementService.CreateDevBox(parameters, developerId);
-            operation.UpdateProgress(Resources.GetResource(CreationResponseReceivedProgressKey, parameters.DevBoxName, parameters.ProjectName), Constants.IndefiniteProgress);
+            operation.UpdateProgress(Resources.GetResource(CreationResponseReceivedProgressKey, parameters.NewEnvironmentName, parameters.ProjectName), Constants.IndefiniteProgress);
 
             var devBoxState = JsonSerializer.Deserialize<DevBoxMachineState>(result.JsonResponseRoot.ToString(), Constants.JsonOptions)!;
             var devBox = _devBoxInstanceFactory(developerId, devBoxState);
 
-            operation.UpdateProgress(Resources.GetResource(DevCenterCreationStartedProgressKey, parameters.DevBoxName, parameters.ProjectName), Constants.IndefiniteProgress);
+            operation.UpdateProgress(Resources.GetResource(DevCenterCreationStartedProgressKey, parameters.NewEnvironmentName, parameters.ProjectName), Constants.IndefiniteProgress);
 
             var callback = DevCenterLongRunningOperationCallback(devBox);
 
             // Now we can start querying the Dev Center for the creation status of the Dev Box operation. This operation will continue until the Dev Box is ready for use.
             var operationUri = result.ResponseHeader.OperationLocation;
-            var operationid = Guid.Parse(operationUri!.Segments.Last());
+            var operationId = Guid.Parse(operationUri!.Segments.Last());
 
-            _devBoxOperationWatcher.StartDevCenterOperationMonitor(developerId, operationUri!, operationid, DevBoxActionToPerform.Create, callback);
+            _devBoxOperationWatcher.StartDevCenterOperationMonitor(developerId, operationUri!, operationId, DevBoxActionToPerform.Create, callback);
 
             // At this point the DevBox is partially created in the cloud. However the DevBox is not ready for use. Querying for all Dev Box will
             // return this DevBox via Json with its provisioningState set to "Provisioning". So, we'll keep track of the operation.
@@ -75,8 +77,8 @@ public class DevBoxCreationManager : IDevBoxCreationManager
         }
         catch (Exception ex)
         {
-            _log.Error($"unable to create the Dev Box with user options: {parameters}", ex);
-            return new CreateComputeSystemResult(ex, Resources.GetResource(CreationErrorProgressKey, parameters.DevBoxName, parameters.ProjectName), ex.Message);
+            _log.Error(ex, $"unable to create the Dev Box with user options: {parameters}");
+            return new CreateComputeSystemResult(ex, Resources.GetResource(CreationErrorProgressKey, parameters.NewEnvironmentName, parameters.ProjectName, ex.Message), ex.Message);
         }
     }
 
@@ -84,6 +86,7 @@ public class DevBoxCreationManager : IDevBoxCreationManager
     {
         return (DevCenterOperationStatus? status) =>
             {
+                _log.Information($"Long running operation status: '{status}' received for DevBox: {devBox.DisplayName}, Id: {devBox.Id}.");
                 switch (status)
                 {
                     case DevCenterOperationStatus.NotStarted:

--- a/src/AzureExtension/Services/DevBox/DevBoxOperationWatcher.cs
+++ b/src/AzureExtension/Services/DevBox/DevBoxOperationWatcher.cs
@@ -72,6 +72,8 @@ public class DevBoxOperationWatcher : IDevBoxOperationWatcher
             {
                 try
                 {
+                    _log.Information($"Starting Dev Box operation with action {actionToPerform}, Uri: {operationUri}, Id: {operationId}");
+
                     // Query the Dev Center for the status of the Dev Box operation.
                     var result = await _managementService.HttpsRequestToDataPlane(operationUri, developerId, HttpMethod.Get, null);
                     var operation = JsonSerializer.Deserialize<DevCenterOperationBase>(result.JsonResponseRoot.ToString(), Constants.JsonOptions)!;
@@ -132,6 +134,8 @@ public class DevBoxOperationWatcher : IDevBoxOperationWatcher
             {
                 try
                 {
+                    _log.Information($"Starting the provisioning monitor for Dev Box with Name: '{devBoxInstance.DisplayName}' , Id: '{devBoxInstance.Id}'");
+
                     // Query the Dev Center for the provisioning status of the Dev Box. This is needed for when the Dev Box was created outside of Dev Home.
                     var devBoxUri = $"{devBoxInstance.DevBoxState.Uri}?{Constants.APIVersion}";
                     var result = await _managementService.HttpsRequestToDataPlane(new Uri(devBoxUri), developerId, HttpMethod.Get, null);

--- a/src/AzureExtension/Services/DevBox/TimeSpanService.cs
+++ b/src/AzureExtension/Services/DevBox/TimeSpanService.cs
@@ -28,7 +28,7 @@ public class TimeSpanService : ITimeSpanService
         switch (actionToPerform)
         {
             case DevBoxActionToPerform.Create:
-                return Constants.FiveMinutePeriod;
+                return Constants.ThreeMinutePeriod;
             default:
                 return Constants.OneMinutePeriod;
         }

--- a/src/AzureExtension/Strings/en-US/Resources.resw
+++ b/src/AzureExtension/Strings/en-US/Resources.resw
@@ -431,4 +431,80 @@
     <value>Dev Boxes aren't configured for the current account.</value>
     <comment>Error shown when Dev Boxes aren't configured for the current account.</comment>
   </data>
+  <data name="SettingsCardLabel" xml:space="preserve">
+    <value>Choose an image to use</value>
+    <comment>Label text for a list of cards that appear in the UI</comment>
+  </data>
+  <data name="DevBox_SecondaryButtonLabelForCreationFlow" xml:space="preserve">
+    <value>Previous</value>
+    <comment>Text to display to the user about what the secondary button does in the UI.</comment>
+  </data>
+  <data name="DevBox_PrimaryButtonLabelForCreationFlow" xml:space="preserve">
+    <value>Next</value>
+    <comment>Text to display to the user about what the primary button does in the UI</comment>
+  </data>
+  <data name="DevBox_EnterNewEnvironmentTextBoxLabel" xml:space="preserve">
+    <value>Enter a name for your Microsoft DevBox</value>
+    <comment>Label text for textbox where users will enter the name for their Dev Box</comment>
+  </data>
+  <data name="DevBox_ReviewPageNameLabel" xml:space="preserve">
+    <value>Name{0}</value>
+    <comment>Label text for textbox where users will enter the name for their Dev Box</comment>
+  </data>
+  <data name="DevBox_ProjectComboBoxLabel" xml:space="preserve">
+    <value>Select a project</value>
+    <comment>Label text for combo box where users will select the project their Dev Box will be created in</comment>
+  </data>
+  <data name="DevBox_ReviewPageProjectNameLabel" xml:space="preserve">
+    <value>Project{0}</value>
+    <comment>Label text in Dev Homes review page that will display the name of the project the user selected in the wizard flow. {0} is a punctuation like ':'</comment>
+  </data>
+  <data name="DevBox_ReviewPagePoolNameLabel" xml:space="preserve">
+    <value>Pool{0}</value>
+    <comment>Label text in Dev Homes review page that will display the name of the pool the user selected in the wizard flow. {0} is a punctuation like ':'</comment>
+  </data>
+  <data name="DevBox_PoolComboBoxLabel" xml:space="preserve">
+    <value>Select a pool</value>
+    <comment>Label text for combo box where users will select the pool their Dev Box will be created in</comment>
+  </data>
+  <data name="DevBox_PoolsButtonLabel" xml:space="preserve">
+    <value>View Pools</value>
+    <comment>Label text for combo box where users will select the pool their Dev Box will be created in</comment>
+  </data>
+  <data name="DevBox_InitialCreationFormGenerationFailedError" xml:space="preserve">
+    <value>Failed to generate the initial creation form</value>
+    <comment>Error text to show the user when there was an error getting the project names for the dev box creation wizard</comment>
+  </data>
+  <data name="DevBox_ReviewFormGenerationFailedError" xml:space="preserve">
+    <value>Failed to generate the review form</value>
+    <comment>Error text to show the user when the was an error getting the review page for dev box creation wizard</comment>
+  </data>
+  <data name="DevBox_TextBoxErrorMessage" xml:space="preserve">
+    <value>Please enter a name that contains more than three characters, uses only alphanumeric characters and hyphens, and does not start with a hypen</value>
+    <comment>Error text to show the user when the name of the new Dev Box they've entered does not match the criteria</comment>
+  </data>
+  <data name="DevBox_ProjectComboBoxErrorMessage" xml:space="preserve">
+    <value>A project must be selected</value>
+    <comment>Error text to show the user when the user does not select a project name in the project combo box</comment>
+  </data>
+  <data name="DevBox_PoolsComboBoxErrorMessage" xml:space="preserve">
+    <value>A pool must be selected</value>
+    <comment>Error text to show the user when the user does not select a pool name in the pools combo box</comment>
+  </data>
+  <data name="DevBox_PoolSubtitle" xml:space="preserve">
+    <value>{0} vCPU {1} GB RAM {2} GB Storage</value>
+    <comment>Text to describe the hardware specs for a machine</comment>
+  </data>
+  <data name="DevBox_AdaptiveCardStateNotRecognizedError" xml:space="preserve">
+    <value>Adaptive card state not recognized</value>
+    <comment>Error text to show when we don't recognize the state of the adaptive card that was given to us</comment>
+  </data>
+  <data name="DevBox_ReviewFormGenerationFailedError" xml:space="preserve">
+    <value>Failed to generate the review form</value>
+    <comment>Error text to show the user when the was an error getting the review page in the creation wizard flow</comment>
+  </data>
+  <data name="DevBox_PoolsPlaceHolder" xml:space="preserve">
+    <value>Please select a pool closest to your physical location for optimal performance</value>
+    <comment>text instructions to show the user in the select pools drop down box</comment>
+  </data>
 </root>

--- a/src/AzureExtension/Strings/en-US/Resources.resw
+++ b/src/AzureExtension/Strings/en-US/Resources.resw
@@ -502,6 +502,7 @@
   <data name="DevBox_PoolsPlaceHolder" xml:space="preserve">
     <value>Please select a pool closest to your physical location for optimal performance</value>
     <comment>text instructions to show the user in the select pools drop down box</comment>
+  </data>
   <data name="DevBox_ConfigApplyFailedKey" xml:space="preserve">
     <value>Applying the configuration failed</value>
     <comment>Error message when applying the configuration failed.</comment>

--- a/test/AzureExtension/DevBox/DevBoxTests.cs
+++ b/test/AzureExtension/DevBox/DevBoxTests.cs
@@ -38,6 +38,7 @@ public partial class DevBoxTests
         var contentList = new List<HttpContent>
         {
             new StringContent(MockProjectJson),
+            new StringContent(MockTestPoolJson),
             new StringContent(MockDevBoxListJson),
         };
         UpdateHttpClientResponseMock(contentList);

--- a/test/AzureExtension/DevBox/DevBoxTests.cs
+++ b/test/AzureExtension/DevBox/DevBoxTests.cs
@@ -99,6 +99,7 @@ public partial class DevBoxTests
         var contentList = new List<HttpContent>
         {
             new StringContent(MockProjectJson),
+            new StringContent(MockTestPoolJson),
             new StringContent(devBoxListPoweredOffJson),
             new StringContent(MockTestOperationJson), // initial operation status with 'Running' status
             new StringContent(succeededJson), // ending operation status with 'Succeeded' status

--- a/test/AzureExtension/DevBox/DevBoxTestsSetup.cs
+++ b/test/AzureExtension/DevBox/DevBoxTestsSetup.cs
@@ -111,6 +111,33 @@ public partial class DevBoxTests : IDisposable
               ""startTime"": ""2024-02-20T08:23:16.8547869+00:00""
         }";
 
+    private const string MockTestPoolJson =
+        @"{
+          ""uri"": ""https://8a40af38-3b4c-4672-a6a4-5e964b1870ed-contosodevcenter.centralus.devcenter.azure.com/projects/myProject/users/b08e39b4-2ac6-4465-a35e-48322efb0f98/devboxes/MyDevBox"",
+          ""name"": ""MyDevBox"",
+          ""provisioningState"": ""Succeeded"",
+          ""projectName"": ""ContosoProject"",
+          ""poolName"": ""LargeDevWorkStationPool"",
+          ""location"": ""centralus"",
+          ""osType"": ""Windows"",
+          ""user"": ""b08e39b4-2ac6-4465-a35e-48322efb0f98"",
+          ""hardwareProfile"": {
+            ""vCPUs"": 8,
+            ""memoryGB"": 32
+          },
+          ""storageProfile"": {
+            ""osDisk"": {
+              ""diskSizeGB"": 1024
+            }
+          },
+          ""hibernateSupport"": ""Enabled"",
+          ""imageReference"": {
+            ""name"": ""DevImage"",
+            ""version"": ""1.0.0"",
+            ""publishedDate"": ""2022-03-01T00:13:23.323Z""
+          }
+        }";
+
     private const string MockTestRemoteConnectionJson =
         @"{
               ""webUrl"": ""https://devcenter.azure.com/projects/project/users/b214d34a-3feb-12ab-96bd-cca70d0c9d69/devboxes/DevBox1"",

--- a/test/AzureExtension/DevBox/DevBoxTestsSetup.cs
+++ b/test/AzureExtension/DevBox/DevBoxTestsSetup.cs
@@ -119,7 +119,7 @@ public partial class DevBoxTests : IDisposable
 
     private const string MockTestCreationParametersJson =
         @"{
-              ""devBoxName"": ""MyDevBox"",
+              ""NewEnvironmentName"": ""MyDevBox"",
               ""projectName"": ""MyProject"",
               ""poolName"": ""MyPoolName"",
               ""devCenterUri"": ""https://devcenter.azure.com""


### PR DESCRIPTION
## Summary of the pull request

A Supplemental PR into Dev Home needs to be submitted first before checking this in: https://github.com/microsoft/devhome/pull/2639

This PR adds DevBox creation UI to the Azure extension and changes the following:

- Adds the CreationAdaptiveCardSession which Dev Home will interaction when presenting the user with an initial creation page and a review page. The initial page contains a textbox, a projects combo box and a pools combo box. When Dev Home requests the creation session if the project and pools have not been retrieved yet, we retrieve them and get the Dev Boxes before returning the session.
- Data for the pools for all projects is retrieved and sent in the adaptive card payload back to Dev Home.
- Dev Home will use this data to dynamically update the data for the pools combo box based on the selection within the projects combo box.
- I've added two adaptive card templates `CreationForm.json` and `ReviewForm.json`. The first will be sent as the initial page. When the user selects the next button in Dev Home the review page will be sent. If the user selects the previous button the creation page will be sent. If the user is on the review page and selects next we capture their input, stop the session and send it back to Dev Home. Dev Home will them re-show the review page back to the user once creation of the Dev Box has begun.

Video of flow:


https://github.com/microsoft/DevHomeAzureExtension/assets/105318831/091a8977-3e72-4330-b925-f3c4e2c7a30d




## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
