### PR TITLE
Workaround for GetQueryResultCountAsync not working as expected

### DIFF
--- a/src/AzureExtension/DataManager/AzureDataManager.cs
+++ b/src/AzureExtension/DataManager/AzureDataManager.cs
@@ -40,7 +40,7 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
     public static readonly int PullRequestResultLimit = 25;
 
     // Max number of query results to fetch for a given query.
-    public static readonly int QueryResultLimit = 25;
+    public static readonly int QueryResultLimit = 26;
 
     // Most data that has not been updated within this time will be removed.
     private static readonly TimeSpan DataRetentionTime = TimeSpan.FromDays(1);

--- a/src/AzureExtension/DataManager/AzureDataManager.cs
+++ b/src/AzureExtension/DataManager/AzureDataManager.cs
@@ -327,7 +327,6 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
             }
 
             var queryId = new Guid(azureUri.Query);
-            var count = await witClient.GetQueryResultCountAsync(project.Name, queryId);
             var queryResult = await witClient.QueryByIdAsync(project.InternalId, queryId);
             if (queryResult == null)
             {
@@ -481,7 +480,7 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
             };
 
             var serializedJson = JsonSerializer.Serialize(workItemsObj, serializerOptions);
-            Query.GetOrCreate(DataStore, azureUri.Query, project.Id, parameters.DeveloperId.LoginId, getQueryResult.Name, serializedJson, count);
+            Query.GetOrCreate(DataStore, azureUri.Query, project.Id, parameters.DeveloperId.LoginId, getQueryResult.Name, serializedJson, workItemIds.Count);
         } // Foreach AzureUri
 
         return;

--- a/src/AzureExtension/Widgets/AzureQueryTilesWidget.cs
+++ b/src/AzureExtension/Widgets/AzureQueryTilesWidget.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Globalization;
 using System.Text.Json.Nodes;
 using DevHomeAzureExtension.Client;
 using DevHomeAzureExtension.DataManager;
@@ -270,10 +271,16 @@ internal sealed class AzureQueryTilesWidget : AzureWidget
                             workItemCount = (int)queryInfo.QueryResultCount;
                         }
 
+                        var workItemCountDisplay = workItemCount.ToString(CultureInfo.InvariantCulture);
+                        if (workItemCount == 25)
+                        {
+                            workItemCountDisplay = $">25";
+                        }
+
                         var tile = new JsonObject
                         {
                             { "title", tiles[pos].Title },
-                            { "counter", workItemCount },
+                            { "counter", workItemCountDisplay },
                             { "backgroundImage", IconLoader.GetIconAsBase64("BlueBackground.png") },
                             { "url", tiles[pos].AzureUri.ToString() },
                         };

--- a/src/AzureExtension/Widgets/AzureQueryTilesWidget.cs
+++ b/src/AzureExtension/Widgets/AzureQueryTilesWidget.cs
@@ -272,7 +272,7 @@ internal sealed class AzureQueryTilesWidget : AzureWidget
                         }
 
                         var workItemCountDisplay = workItemCount.ToString(CultureInfo.InvariantCulture);
-                        if (workItemCount == 25)
+                        if (workItemCount > 25)
                         {
                             workItemCountDisplay = $">25";
                         }


### PR DESCRIPTION
## Summary of the pull request
The endpoint of GetQueryResultCountAsync has a header bug which makes it unusable to us. This fix works around that endpoint so we do not need it to have functional widgets. 

However, while Query Tiles widget will work, but it will not show any count higher than 25, as that is the size of the work items we pull for the Query Results. In addition, the Query Result widget will not show an indicator that more than 25 results were found at the bottom of the widget. It only shows 25 and used the count to identify when more than 25 were found. 

The Query Tiles widget will show ">25" when it has more than 25 results so the user is not mislead into thinking there are 25 results when there are in fact more than 25. Since we do not know exactly, we will display > 25.

Due to the above two reductions in functionality, this is not a permanent fix; this is a temporary fix to get Query Result widget functional and Query Tiles with limited functionality. We will want to revert this commit and use GetQueryResultCountAsync once the endpoint fix is deployed. The ETA for that is a few weeks, so likely reverted in the next AzureExtension release.

## References and relevant issues
Closes #155 

## Detailed description of the pull request / Additional comments
After discussion with Azure team it was identified that the endpoint GetQueryResultCountAsync has a header bug, and while that is being fixed by Azure, we are broken until the fix is deployed unless we stop using that endpoint. This fix stops calling that endpoint and instead gets the count another way, by using the count of WorkItemIds used by the Query Results.

However, the WorkItemId count is capped at 25 for performance reasons, which means Query Tiles will not have the true count of work items for a query. It will instead be capped at 25, so queries with more than 25 results will show only 25. While this is not ideal, it is better than a broken widget.

This fix is intended to unblock widgets from not working at all by not calling GetQueryResultCountAsync, and use the work item id count instead. This number will be the equivalent when results are <= 25, but incorrect when results are greater than 25. We will not know the total count because the endpoint to get that information is not working.
 
## Validation steps performed
* Verifed Query Results and Query Tiles widgets work with fix.
* Verified Query Tiles does indeed cap at 25 (as expected, described above).

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
