### PR TITLE
Show correct completion state after Dev Box creation and handle deletion during creation

### DIFF
--- a/src/AzureExtension/Contracts/IDevBoxOperationWatcher.cs
+++ b/src/AzureExtension/Contracts/IDevBoxOperationWatcher.cs
@@ -18,7 +18,7 @@ public interface IDevBoxOperationWatcher
     /// <param name="developerId">The developer to authenticate with</param>
     /// <param name="operationUri">The Uri associated with the operation. It is the Uri that the operation will continuously query</param>
     /// <param name="operationId">The Id of the operation provided by the Dev Center</param>
-    /// <param name="actionToPerform">The DevBox action assocated with the operation</param>
+    /// <param name="actionToPerform">The DevBox action associated with the operation</param>
     /// <param name="completionCallback">A callback  operation to be invoked once the operation completes</param>
     public void StartDevCenterOperationMonitor(IDeveloperId developerId, Uri operationUri, Guid operationId, DevBoxActionToPerform actionToPerform, Action<DevCenterOperationStatus?> completionCallback);
 
@@ -26,8 +26,21 @@ public interface IDevBoxOperationWatcher
     /// Method used to monitor the provisioning status of a Dev Box that was created outside of the extension.
     /// </summary>
     /// <param name="developerId">The developer to authenticate with</param>
-    /// <param name="actionToPerform">The DevBox action assocated with the operation</param>
+    /// <param name="actionToPerform">The DevBox action associated with the operation</param>
     /// <param name="devBoxInstance">The DevBox instance whose provisioning status is being watched.</param>
     /// <param name="completionCallback">A callback  operation to be invoked once the operation completes</param>
     public void StartDevBoxProvisioningStatusMonitor(IDeveloperId developerId, DevBoxActionToPerform actionToPerform, DevBoxInstance devBoxInstance, Action<DevBoxInstance> completionCallback);
+
+    /// <summary>
+    /// Stops and removes the thread pool timer associated with a Guid Id.
+    /// </summary>
+    /// <param name="id">The Id associated with the thread pool timer</param>
+    public void RemoveTimerIfBeingWatched(Guid id);
+
+    /// <summary>
+    /// Get whether the provided Dev Box or Dev Box operation Id is being watched by the watcher.
+    /// </summary>
+    /// <param name="id">The Id associated with the thread pool timer</param>
+    /// <returns>True when the Id is currently being watched and false otherwise</returns>
+    public bool IsIdBeingWatched(Guid id);
 }

--- a/src/AzureExtension/DevBox/DevBoxInstance.cs
+++ b/src/AzureExtension/DevBox/DevBoxInstance.cs
@@ -248,6 +248,13 @@ public class DevBoxInstance : IComputeSystem, IComputeSystem2
                     IsOperationInProgress = true;
                 }
 
+                // Remove any operation that's being watched by the operation watcher now that the user has chosen to delete
+                // the Dev Box.
+                if (action == DevBoxActionToPerform.Delete)
+                {
+                    _devBoxOperationWatcher.RemoveTimerIfBeingWatched(Guid.Parse(Id));
+                }
+
                 CurrentActionToPerform = action;
                 var operation = DevBoxOperationHelper.ActionToPerformToString(action);
 

--- a/src/AzureExtension/DevBox/Models/DevCenterOperationBase.cs
+++ b/src/AzureExtension/DevBox/Models/DevCenterOperationBase.cs
@@ -30,4 +30,9 @@ public class DevCenterOperationBase
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public DateTime? EndTime { get; set; }
+
+    public override string ToString()
+    {
+        return $"Status: {Status}, StartTime: {StartTime}, EndTime: {EndTime}";
+    }
 }

--- a/test/AzureExtension/DevBox/DevBoxTestsSetup.cs
+++ b/test/AzureExtension/DevBox/DevBoxTestsSetup.cs
@@ -76,7 +76,7 @@ public partial class DevBoxTests : IDisposable
                     ""provisioningState"": ""Succeeded"",
                     ""actionState"": ""Stopped"",
                     ""powerState"": ""Deallocated"",
-                    ""uniqueId"": ""28feedaeb-996b-434b-bb57-4969cbeef8f0"",
+                    ""uniqueId"": ""28feedae-996b-434b-bb57-4969cbeef8f0"",
                     ""location"": ""westus2"",
                     ""osType"": ""Windows"",
                     ""user"": ""28feedaeb-996b-434b-bb57-4969cbeef8f0"",


### PR DESCRIPTION
## Summary of the pull request
This PR accomplishes two things:

1. When you create a Dev Box, the Dev Center sends back the state of the Dev Box with the provisioning status set to "creating". In the past what we'd do is once the operation has completed, we'd set the provisioning state to succeeded, however now that we have many different states that the Dev Box can be in, in this method:https://github.com/microsoft/DevHomeAzureExtension/blob/deaf3be2371af6cc7e31d4c4fa0198b3c185cb5d/src/AzureExtension/DevBox/DevBoxInstance.cs#L408 simply setting the provisioning state to succeeded, would result in the state returning as stopped. As the initial Dev Box state retrieved from the Dev Center has an action state of "unknown" and no powerstate. This would cause us to hit this line: https://github.com/microsoft/DevHomeAzureExtension/blob/deaf3be2371af6cc7e31d4c4fa0198b3c185cb5d/src/AzureExtension/DevBox/DevBoxInstance.cs#L469  This causes users to think the Dev Box is stopped, when in actuality its actually running and ready to be used. When users click the sync button they would then see the actual state of the new Dev Box, which would be "running". To fix this without them having to click the sync button we simply use the OperationCallback method already within the DevBoxInstance class that takes an operation status. When the operation status is succeeded, it will query the Dev Center for its new state then invoke the state changed event to notify Dev Home of the new state. We no longer need to set the provisioning state manually.

The second thing this PR updates is allowing long running operations to be stopped when a delete action is initiated by the user. The delete action in terms of the actions we support is the only action that can be initiated while other operations are still in progress. (We're following the same pattern as devbox.microsoft.com)

1. When a delete action is initiated we'll remove/stop any operation that we're watching within the extension, then initiate the delete operation. 

I also fixed the spelling of some of the comments

Video where we see after creation the correct state is shown:

https://github.com/microsoft/DevHomeAzureExtension/assets/105318831/63fea1bc-2e1b-4eff-b05f-84184498e411



## References and relevant issues

## Detailed description of the pull request / Additional comments
related: https://github.com/microsoft/devhome/pull/2732
## Validation steps performed

## PR checklist
- [ ] Closes https://github.com/microsoft/devhome/issues/2714
- [ ] Closes https://github.com/microsoft/devhome/issues/2746
- [ ] Tests added/passed
- [ ] Documentation updated
