### PR TITLE
Handle "Waiting for user session" Dev Box config status; Fix slow loading

### DIFF
--- a/src/AzureExtension/DevBox/DevBoxProvider.cs
+++ b/src/AzureExtension/DevBox/DevBoxProvider.cs
@@ -142,16 +142,8 @@ public class DevBoxProvider : IComputeSystemProvider
 
         // update the cache every time we retrieve new Dev Boxes. This is used so in the creation flow we don't need
         // to retrieve the Dev Boxes again if the user already retrieved them in the environments page in Dev Home
-        _cachedDevBoxesMap[GetUniqueDeveloperId(developerId)] = devBoxes.ToList();
-
-        // Get Associated pools the first time we get the projects
         var uniqueUserId = GetUniqueDeveloperId(developerId);
-        if (!_devBoxProjectAndPoolsMap.TryGetValue(uniqueUserId, out var _))
-        {
-            _log.Information($"Found no cached pools for all projects for {developerId.LoginId}, retrieving pools");
-            _ = Task.Run(async () => _devBoxProjectAndPoolsMap[uniqueUserId] = await _devBoxManagementService.GetAllProjectsToPoolsMappingAsync(devBoxProjects!, developerId));
-        }
-
+        _cachedDevBoxesMap[uniqueUserId] = devBoxes.ToList();
         return _cachedDevBoxesMap[GetUniqueDeveloperId(developerId)];
     }
 
@@ -231,6 +223,8 @@ public class DevBoxProvider : IComputeSystemProvider
                 {
                     _log.Information($"No cached Dev Boxes found for {developerId.LoginId}, getting new Dev Boxes");
                     await GetDevBoxesAsync(developerId);
+                    _devBoxProjectAndPoolsMap[uniqueId] = await
+                        _devBoxManagementService.GetAllProjectsToPoolsMappingAsync(_devBoxProjectsMap[uniqueId]!, developerId);
                 }
 
                 return new ComputeSystemAdaptiveCardResult(new CreationAdaptiveCardSession(_devBoxProjectAndPoolsMap[uniqueId], _cachedDevBoxesMap[uniqueId]));

--- a/src/AzureExtension/DevBox/DevBoxProvider.cs
+++ b/src/AzureExtension/DevBox/DevBoxProvider.cs
@@ -144,7 +144,7 @@ public class DevBoxProvider : IComputeSystemProvider
         // to retrieve the Dev Boxes again if the user already retrieved them in the environments page in Dev Home
         var uniqueUserId = GetUniqueDeveloperId(developerId);
         _cachedDevBoxesMap[uniqueUserId] = devBoxes.ToList();
-        return _cachedDevBoxesMap[GetUniqueDeveloperId(developerId)];
+        return _cachedDevBoxesMap[uniqueUserId];
     }
 
     /// <summary>

--- a/src/AzureExtension/DevBox/DevBoxProvider.cs
+++ b/src/AzureExtension/DevBox/DevBoxProvider.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using AzureExtension.Contracts;
@@ -117,7 +118,12 @@ public class DevBoxProvider : IComputeSystemProvider
     /// <param name="developerId">DeveloperId to be used by the authentication token service</param>
     public async Task<IEnumerable<IComputeSystem>> GetDevBoxesAsync(IDeveloperId developerId)
     {
+        var timer = new Stopwatch();
+        timer.Start();
+
         var devBoxProjects = await GetDevBoxProjectsAsync(developerId);
+
+        _log.Debug($"--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------> Total time for ARM function: {timer.ElapsedMilliseconds} ms");
 
         if (devBoxProjects?.Data != null)
         {
@@ -140,9 +146,20 @@ public class DevBoxProvider : IComputeSystemProvider
             });
         }
 
+        _log.Debug($"--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------> Total time for parallel projects: {timer.ElapsedMilliseconds} ms");
+
         // update the cache every time we retrieve new Dev Boxes. This is used so in the creation flow we don't need
         // to retrieve the Dev Boxes again if the user already retrieved them in the environments page in Dev Home
         _cachedDevBoxesMap[GetUniqueDeveloperId(developerId)] = devBoxes.ToList();
+
+        // Get Associated pools the first time we get the projects
+        var uniqueUserId = GetUniqueDeveloperId(developerId);
+        if (!_devBoxProjectAndPoolsMap.TryGetValue(uniqueUserId, out var _))
+        {
+            _log.Information($"Found no cached pools for all projects for {developerId.LoginId}, retrieving pools");
+            _ = Task.Run(async () => _devBoxProjectAndPoolsMap[uniqueUserId] = await _devBoxManagementService.GetAllProjectsToPoolsMappingAsync(devBoxProjects!, developerId));
+        }
+
         return _cachedDevBoxesMap[GetUniqueDeveloperId(developerId)];
     }
 
@@ -244,6 +261,9 @@ public class DevBoxProvider : IComputeSystemProvider
     {
         _log.Information($"Attempting to get all projects for {developerId?.LoginId ?? "null"}");
 
+        var timer = new Stopwatch();
+        timer.Start();
+
         ArgumentNullException.ThrowIfNull(developerId);
 
         var uniqueUserId = GetUniqueDeveloperId(developerId);
@@ -254,16 +274,13 @@ public class DevBoxProvider : IComputeSystemProvider
             return projects;
         }
 
+        _log.Debug($"--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------> Time before ARM hit: {timer.ElapsedMilliseconds} ms");
+
         var requestContent = new StringContent(Constants.ARGQuery, Encoding.UTF8, "application/json");
         var result = await _devBoxManagementService.HttpsRequestToManagementPlane(new Uri(Constants.ARGQueryAPI), developerId, HttpMethod.Post, requestContent);
         var devBoxProjects = JsonSerializer.Deserialize<DevBoxProjects>(result.JsonResponseRoot.ToString(), Constants.JsonOptions);
 
-        // Get Associated pools the first time we get the projects
-        if (!_devBoxProjectAndPoolsMap.TryGetValue(uniqueUserId, out var _))
-        {
-            _log.Information($"Found no cached pools for all projects for {developerId.LoginId}, retrieving pools");
-            _ = Task.Run(async () => _devBoxProjectAndPoolsMap[uniqueUserId] = await _devBoxManagementService.GetAllProjectsToPoolsMappingAsync(devBoxProjects!, developerId));
-        }
+        _log.Debug($"--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------> Time after ARM: {timer.ElapsedMilliseconds} ms");
 
         _devBoxProjectsMap.Add(uniqueUserId, devBoxProjects!);
         return devBoxProjects!;

--- a/src/AzureExtension/DevBox/DevBoxProvider.cs
+++ b/src/AzureExtension/DevBox/DevBoxProvider.cs
@@ -262,7 +262,7 @@ public class DevBoxProvider : IComputeSystemProvider
         if (!_devBoxProjectAndPoolsMap.TryGetValue(uniqueUserId, out var _))
         {
             _log.Information($"Found no cached pools for all projects for {developerId.LoginId}, retrieving pools");
-            _devBoxProjectAndPoolsMap[uniqueUserId] = await _devBoxManagementService.GetAllProjectsToPoolsMappingAsync(devBoxProjects!, developerId);
+            _ = Task.Run(async () => _devBoxProjectAndPoolsMap[uniqueUserId] = await _devBoxManagementService.GetAllProjectsToPoolsMappingAsync(devBoxProjects!, developerId));
         }
 
         _devBoxProjectsMap.Add(uniqueUserId, devBoxProjects!);

--- a/src/AzureExtension/DevBox/Exceptions/WingetConfigurationException.cs
+++ b/src/AzureExtension/DevBox/Exceptions/WingetConfigurationException.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureExtension.DevBox.Exceptions;
+
+public class WingetConfigurationException : Exception
+{
+    public WingetConfigurationException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/AzureExtension/DevBox/Helpers/DevBoxOperationHelper.cs
+++ b/src/AzureExtension/DevBox/Helpers/DevBoxOperationHelper.cs
@@ -48,7 +48,7 @@ public static class DevBoxOperationHelper
             "Running" => ConfigurationUnitState.InProgress,
             "Skipped" => ConfigurationUnitState.Skipped,
             "Succeeded" => ConfigurationUnitState.Completed,
-            "Failed" => ConfigurationUnitState.Unknown,
+            "Failed" => ConfigurationUnitState.Completed,
             "TimedOut" => ConfigurationUnitState.Unknown,
             "WaitingForUserSession" => ConfigurationUnitState.Pending,
             _ => ConfigurationUnitState.Unknown,

--- a/src/AzureExtension/DevBox/Helpers/DevBoxOperationHelper.cs
+++ b/src/AzureExtension/DevBox/Helpers/DevBoxOperationHelper.cs
@@ -48,7 +48,7 @@ public static class DevBoxOperationHelper
             "Running" => ConfigurationUnitState.InProgress,
             "Skipped" => ConfigurationUnitState.Skipped,
             "Succeeded" => ConfigurationUnitState.Completed,
-            "Failed" => ConfigurationUnitState.Completed,
+            "Failed" => ConfigurationUnitState.Unknown,
             "TimedOut" => ConfigurationUnitState.Unknown,
             "WaitingForUserSession" => ConfigurationUnitState.Pending,
             _ => ConfigurationUnitState.Unknown,

--- a/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
+++ b/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
@@ -192,7 +192,7 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
     private void SetStateForCustomizationTask(TaskJSONToCSClasses.BaseClass response)
     {
         var setState = DevBoxOperationHelper.JSONStatusToSetStatus(response.Status);
-        _log.Debug($">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>Set Status: {response.Status}");
+        _log.Debug($"Set Status: {response.Status}");
 
         // No need to show the pending status more than once
         if (_pendingNotificationShown && setState == ConfigurationSetState.Pending)
@@ -247,6 +247,7 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
                     ApplyConfigurationActionRequiredEventArgs eventArgs = new(new WaitingForUserAdaptiveCardSession(_resumeEvent));
                     ActionRequired?.Invoke(this, eventArgs);
                     WaitHandle.WaitAny(new[] { _resumeEvent });
+                    Thread.Sleep(TimeSpan.FromMinutes(2));
                 }
 
                 break;
@@ -284,7 +285,7 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
                 var setStatus = string.Empty;
                 while (setStatus != "Succeeded" && setStatus != "Failed" && setStatus != "ValidationFailed")
                 {
-                    await Task.Delay(TimeSpan.FromSeconds(10));
+                    await Task.Delay(TimeSpan.FromSeconds(15));
                     var poll = await _managementService.HttpsRequestToDataPlane(new Uri(_restAPI), _devId, HttpMethod.Get, null);
                     var rawResponse = poll.JsonResponseRoot.ToString();
                     var response = JsonSerializer.Deserialize<TaskJSONToCSClasses.BaseClass>(rawResponse, _taskJsonSerializerOptions);

--- a/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
+++ b/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
@@ -192,7 +192,7 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
     private void SetStateForCustomizationTask(TaskJSONToCSClasses.BaseClass response)
     {
         var setState = DevBoxOperationHelper.JSONStatusToSetStatus(response.Status);
-        _log.Debug($"Set Status: {response.Status}");
+        _log.Debug($">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>Set Status: {response.Status}");
 
         // No need to show the pending status more than once
         if (_pendingNotificationShown && setState == ConfigurationSetState.Pending)
@@ -247,7 +247,6 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
                     ApplyConfigurationActionRequiredEventArgs eventArgs = new(new WaitingForUserAdaptiveCardSession(_resumeEvent));
                     ActionRequired?.Invoke(this, eventArgs);
                     WaitHandle.WaitAny(new[] { _resumeEvent });
-                    Thread.Sleep(TimeSpan.FromMinutes(2));
                 }
 
                 break;
@@ -285,7 +284,7 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
                 var setStatus = string.Empty;
                 while (setStatus != "Succeeded" && setStatus != "Failed" && setStatus != "ValidationFailed")
                 {
-                    await Task.Delay(TimeSpan.FromSeconds(15));
+                    await Task.Delay(TimeSpan.FromSeconds(10));
                     var poll = await _managementService.HttpsRequestToDataPlane(new Uri(_restAPI), _devId, HttpMethod.Get, null);
                     var rawResponse = poll.JsonResponseRoot.ToString();
                     var response = JsonSerializer.Deserialize<TaskJSONToCSClasses.BaseClass>(rawResponse, _taskJsonSerializerOptions);

--- a/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
+++ b/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
@@ -240,14 +240,14 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
                 }
 
                 // If waiting for user session and no task is running, show the adaptive card
-                // We add a wait since Dev Boxes take at least 2 minutes to start applying
+                // We add a wait since Dev Boxes take a little over 2 minutes to start applying
                 // the configuration and we don't want to show the same message immediately after.
                 if (isWaitingForUserSession && !isAnyTaskRunning)
                 {
                     ApplyConfigurationActionRequiredEventArgs eventArgs = new(new WaitingForUserAdaptiveCardSession(_resumeEvent));
                     ActionRequired?.Invoke(this, eventArgs);
                     WaitHandle.WaitAny(new[] { _resumeEvent });
-                    Thread.Sleep(TimeSpan.FromMinutes(2));
+                    Thread.Sleep(TimeSpan.FromSeconds(135));
                 }
 
                 break;

--- a/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
+++ b/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
@@ -192,7 +192,7 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
     private void SetStateForCustomizationTask(TaskJSONToCSClasses.BaseClass response)
     {
         var setState = DevBoxOperationHelper.JSONStatusToSetStatus(response.Status);
-        _log.Debug($"Set Status: {response.Status}");
+        _log.Information($"Set Status: {response.Status}");
 
         // No need to show the pending status more than once
         if (_pendingNotificationShown && setState == ConfigurationSetState.Pending)
@@ -213,7 +213,7 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
                 for (var i = 0; i < _units.Count; i++)
                 {
                     var responseStatus = response.Tasks[i].Status;
-                    _log.Debug($"Unit Response Status: {responseStatus}");
+                    _log.Information($"Unit Response Status: {responseStatus}");
 
                     // If the status is waiting for a user session, there is no need to check for other
                     // individual task statuses.

--- a/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
+++ b/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
@@ -4,6 +4,7 @@
 using System.Text;
 using System.Text.Json;
 using AzureExtension.Contracts;
+using AzureExtension.DevBox.Exceptions;
 using DevHomeAzureExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 using Windows.Foundation;
@@ -70,7 +71,7 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
 
     private Serilog.ILogger _log;
 
-    private ConfigurationUnitState[] _oldUnitState = Array.Empty<ConfigurationUnitState>();
+    private string[] _oldUnitState = Array.Empty<string>();
 
     private bool _pendingNotificationShown;
 
@@ -160,8 +161,30 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
             _fullTaskJSON = fullTask.ToString();
 
             _units = units;
-            _oldUnitState = Enumerable.Repeat(ConfigurationUnitState.Unknown, units.Count).ToArray();
+            _oldUnitState = Enumerable.Repeat(string.Empty, units.Count).ToArray();
         }
+    }
+
+    private void HandleEndState(TaskJSONToCSClasses.BaseClass response, bool isSetSuccessful = false)
+    {
+        List<ApplyConfigurationUnitResult> unitResults = new();
+        var failureResult = new ConfigurationUnitResultInformation(
+            new WingetConfigurationException("Runtime Failure"), string.Empty, string.Empty, ConfigurationUnitResultSource.UnitProcessing);
+
+        for (var i = 0; i < _units.Count; i++)
+        {
+            var task = _units[i];
+            if (isSetSuccessful || response.Tasks[i].Status == "Succeeded")
+            {
+                unitResults.Add(new(task, ConfigurationUnitState.Completed, false, false, null));
+            }
+            else
+            {
+                unitResults.Add(new(task, ConfigurationUnitState.Completed, false, false, failureResult));
+            }
+        }
+
+        _applyConfigurationSetResult = new(null, unitResults);
     }
 
     private void SetStateForCustomizationTask(TaskJSONToCSClasses.BaseClass response)
@@ -183,55 +206,59 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
                 break;
 
             case "Running":
+                bool isAnyTaskRunning = false;
+                bool isWaitingForUserSession = false;
                 for (var i = 0; i < _units.Count; i++)
                 {
                     var responseStatus = response.Tasks[i].Status;
-                    var unitState = DevBoxOperationHelper.JSONStatusToUnitStatus(responseStatus);
+                    _log.Debug($"Unit Response Status: {responseStatus}");
 
                     // If the status is waiting for a user session, there is no need to check for other
-                    // individual task statuses. We add a wait since Winget takes time to start applying
-                    // the configuration and we don't want to show the same message immediately after.
+                    // individual task statuses.
                     if (responseStatus == "WaitingForUserSession")
                     {
-                        ApplyConfigurationActionRequiredEventArgs eventArgs = new(new WaitingForUserAdaptiveCardSession(_resumeEvent));
-                        ActionRequired?.Invoke(this, eventArgs);
-                        WaitHandle.WaitAny(new[] { _resumeEvent });
-                        Thread.Sleep(TimeSpan.FromSeconds(30));
-                        break;
+                        isWaitingForUserSession = true;
+                        continue;
                     }
-                    else if (_oldUnitState[i] != unitState)
+
+                    if (responseStatus == "Running")
+                    {
+                        isAnyTaskRunning = true;
+                    }
+
+                    if (_oldUnitState[i] != responseStatus)
                     {
                         var task = _units[i];
+                        var unitState = DevBoxOperationHelper.JSONStatusToUnitStatus(responseStatus);
                         ConfigurationSetStateChangedEventArgs args = new(new(ConfigurationSetChangeEventType.UnitStateChanged, setState, unitState, null, task));
                         ConfigurationSetStateChanged?.Invoke(this, args);
-                        _oldUnitState[i] = unitState;
+                        _oldUnitState[i] = responseStatus;
                     }
-
-                    _log.Information($"Unit Status: {unitState}");
                 }
 
-                break;
-
-            case "Succeeded":
-                List<ApplyConfigurationUnitResult> unitResults = new();
-                for (var i = 0; i < _units.Count; i++)
+                // If waiting for user session and no task is running, show the adaptive card
+                // We add a wait since Dev Boxes take at least 2 minutes to start applying
+                // the configuration and we don't want to show the same message immediately after.
+                if (isWaitingForUserSession && !isAnyTaskRunning)
                 {
-                    var task = _units[i];
-                    unitResults.Add(new(task, ConfigurationUnitState.Completed, false, false, null));
+                    ApplyConfigurationActionRequiredEventArgs eventArgs = new(new WaitingForUserAdaptiveCardSession(_resumeEvent));
+                    ActionRequired?.Invoke(this, eventArgs);
+                    WaitHandle.WaitAny(new[] { _resumeEvent });
+                    Thread.Sleep(TimeSpan.FromMinutes(2));
                 }
 
-                _applyConfigurationSetResult = new(null, unitResults);
                 break;
 
             case "ValidationFailed":
                 _openConfigurationSetResult = new(new FormatException(Resources.GetResource(ValidationFailedKey)), null, null, 0, 0);
                 break;
 
+            case "Succeeded":
+                HandleEndState(response);
+                break;
+
             case "Failed":
-                // To Do: Add case. Currently the API only checks if Winget started the task.
-                // Does not check if the task failed.
-                // Send UnitStateChanged event for the failed task with ResultInfo and ResultSource as UnitProcessing
-                // _applyConfigurationSetResult = new(new ApplicationException(Resources.GetResource(ConfigApplyFailedKey)), null);
+                HandleEndState(response);
                 break;
         }
     }

--- a/src/AzureExtensionServer/Package.appxmanifest
+++ b/src/AzureExtensionServer/Package.appxmanifest
@@ -132,8 +132,8 @@
                           <Icon Path="Widgets\Assets\azureIcon.png" />
                         </Icons>
                         <Screenshots>
-						  <Screenshot Path="Widgets\Assets\QueryTilesScreenshotDark.png" DisplayAltText="Dev Home icon" />
-						</Screenshots>
+                          <Screenshot Path="Widgets\Assets\QueryTilesScreenshotDark.png" DisplayAltText="Dev Home icon" />
+                        </Screenshots>
                       </DarkMode>
                       <LightMode>
                         <Icons>

--- a/src/AzureExtensionServer/Package.appxmanifest
+++ b/src/AzureExtensionServer/Package.appxmanifest
@@ -132,8 +132,8 @@
                           <Icon Path="Widgets\Assets\azureIcon.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\QueryTilesScreenshotDark.png" DisplayAltText="Dev Home icon" />
-                        </Screenshots>
+						  <Screenshot Path="Widgets\Assets\QueryTilesScreenshotDark.png" DisplayAltText="Dev Home icon" />
+						</Screenshots>
                       </DarkMode>
                       <LightMode>
                         <Icons>

--- a/test/AzureExtension/DevBox/DevBoxTests.cs
+++ b/test/AzureExtension/DevBox/DevBoxTests.cs
@@ -38,8 +38,8 @@ public partial class DevBoxTests
         var contentList = new List<HttpContent>
         {
             new StringContent(MockProjectJson),
-            new StringContent(MockTestPoolJson),
             new StringContent(MockDevBoxListJson),
+            new StringContent(MockTestPoolJson),
         };
         UpdateHttpClientResponseMock(contentList);
 
@@ -100,8 +100,8 @@ public partial class DevBoxTests
         var contentList = new List<HttpContent>
         {
             new StringContent(MockProjectJson),
-            new StringContent(MockTestPoolJson),
             new StringContent(devBoxListPoweredOffJson),
+            new StringContent(MockTestPoolJson),
             new StringContent(devBoxListPoweredOffJson),
             new StringContent(MockTestOperationJson), // initial operation status with 'Running' status
             new StringContent(succeededJson), // ending operation status with 'Succeeded' status


### PR DESCRIPTION
## Detailed description of the pull request
1. Currently when applying a config to a Dev Box, if the user isn't signed in, Dev Box REST APIs return a "Waiting for user" status. This is shown in the UI as an Adaptive Card. But Dev Box also needs a little over a couple of minutes to make sure all required services are running once a user does login. This PR adds logic to handle the status better including situations where the user might log off again. And adds more wait.
2. This PR also fixes the slower loading of the compute systems. This is done by parallelizing the query and moving pool mapping code to a background thread.
3. Adds some failure handling for configs. This will be done in more detail in a future PR.

## Validation steps performed
Checked 

## PR checklist
- [ ] Closes #https://github.com/microsoft/devhome/issues/2774
- [ ] Closes #https://github.com/microsoft/devhome/issues/2736
- [ ] Tests added/passed
- [ ] Documentation updated
