### PR TITLE
Copying what the GitHub Extension does for generic errors.

### DIFF
--- a/src/AzureExtension/Providers/RepositoryProvider.cs
+++ b/src/AzureExtension/Providers/RepositoryProvider.cs
@@ -348,12 +348,12 @@ public class RepositoryProvider : IRepositoryProvider2
             catch (LibGit2Sharp.LibGit2SharpException libGitTwoException)
             {
                 _log.Error(libGitTwoException, $"Either no logged in account has access to this repo, or the repo can't be found");
-                return new ProviderOperationResult(ProviderOperationStatus.Failure, libGitTwoException, "LigGit2 threw an exception", "LibGit2 Threw an exception");
+                return new ProviderOperationResult(ProviderOperationStatus.Failure, libGitTwoException, libGitTwoException.Message, libGitTwoException.Message);
             }
             catch (Exception e)
             {
                 _log.Error(e, "Could not clone the repository");
-                return new ProviderOperationResult(ProviderOperationStatus.Failure, e, "Something happened when cloning the repo", "something happened when cloning the repo");
+                return new ProviderOperationResult(ProviderOperationStatus.Failure, e, e.Message, e.Message);
             }
 
             _log.Information($"Repository {repository.RepoUri} successfully cloned to {cloneDestination}");


### PR DESCRIPTION
## Summary of the pull request
The failure message for LigGit2Sharp and Exception is not passed to DevHome.

For example, if Azure had a LibGit2 exception, users would see "Could not clone repo because LibGit2 threw an exception"

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
