### PR TITLE
Config file YAML fix

### DIFF
--- a/src/AzureExtension/DevBox/Helpers/TaskYAMLToCSClasses.cs
+++ b/src/AzureExtension/DevBox/Helpers/TaskYAMLToCSClasses.cs
@@ -73,7 +73,7 @@ public class TaskYAMLToCSClasses
 
         public bool? AllowPrerelease { get; set; }
 
-        public string SecurityContext { get; set; } = string.Empty;
+        public string SecurityContext { get; set; } = "current";
     }
 
     public class Settings

--- a/src/AzureExtension/DevBox/Helpers/TaskYAMLToCSClasses.cs
+++ b/src/AzureExtension/DevBox/Helpers/TaskYAMLToCSClasses.cs
@@ -72,6 +72,8 @@ public class TaskYAMLToCSClasses
         public string Description { get; set; } = string.Empty;
 
         public bool? AllowPrerelease { get; set; }
+
+        public string SecurityContext { get; set; } = string.Empty;
     }
 
     public class Settings

--- a/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
+++ b/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
@@ -112,6 +112,7 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
 
         var deserializer = new DeserializerBuilder()
             .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
             .Build();
         var baseDSC = deserializer.Deserialize<TaskYAMLToCSClasses.BasePackage>(configuration);
 


### PR DESCRIPTION
## Summary of the issue
Changes on Dev Home side added a new property to the configuration YAML being sent. This was causing the extension to throw an exception and fail the configuration task on Dev Boxes.

## Detailed description of the pull request / Additional comments
This PR adds the new parameter and adds "Ignore new parameters" to the de-serealizer 

## Validation steps performed
Tested with a full end-to-end config flow.

## PR checklist
- [ ] Closes #https://github.com/microsoft/devhome/issues/2840
- [ ] Tests added/passed
- [ ] Documentation updated
