### PR TITLE
Revert "Workaround for GetQueryResultCountAsync not working as expected"

### DIFF
--- a/src/AzureExtension/DataManager/AzureDataManager.cs
+++ b/src/AzureExtension/DataManager/AzureDataManager.cs
@@ -40,7 +40,7 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
     public static readonly int PullRequestResultLimit = 25;
 
     // Max number of query results to fetch for a given query.
-    public static readonly int QueryResultLimit = 26;
+    public static readonly int QueryResultLimit = 25;
 
     // Most data that has not been updated within this time will be removed.
     private static readonly TimeSpan DataRetentionTime = TimeSpan.FromDays(1);
@@ -327,6 +327,7 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
             }
 
             var queryId = new Guid(azureUri.Query);
+            var count = await witClient.GetQueryResultCountAsync(project.Name, queryId);
             var queryResult = await witClient.QueryByIdAsync(project.InternalId, queryId);
             if (queryResult == null)
             {
@@ -480,7 +481,7 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
             };
 
             var serializedJson = JsonSerializer.Serialize(workItemsObj, serializerOptions);
-            Query.GetOrCreate(DataStore, azureUri.Query, project.Id, parameters.DeveloperId.LoginId, getQueryResult.Name, serializedJson, workItemIds.Count);
+            Query.GetOrCreate(DataStore, azureUri.Query, project.Id, parameters.DeveloperId.LoginId, getQueryResult.Name, serializedJson, count);
         } // Foreach AzureUri
 
         return;

--- a/src/AzureExtension/Widgets/AzureQueryTilesWidget.cs
+++ b/src/AzureExtension/Widgets/AzureQueryTilesWidget.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Globalization;
 using System.Text.Json.Nodes;
 using DevHomeAzureExtension.Client;
 using DevHomeAzureExtension.DataManager;
@@ -271,16 +270,10 @@ internal sealed class AzureQueryTilesWidget : AzureWidget
                             workItemCount = (int)queryInfo.QueryResultCount;
                         }
 
-                        var workItemCountDisplay = workItemCount.ToString(CultureInfo.InvariantCulture);
-                        if (workItemCount > 25)
-                        {
-                            workItemCountDisplay = $">25";
-                        }
-
                         var tile = new JsonObject
                         {
                             { "title", tiles[pos].Title },
-                            { "counter", workItemCountDisplay },
+                            { "counter", workItemCount },
                             { "backgroundImage", IconLoader.GetIconAsBase64("BlueBackground.png") },
                             { "url", tiles[pos].AzureUri.ToString() },
                         };


### PR DESCRIPTION
## Summary of the pull request
This reverts commit 959bf8c51f83ea2ba0c3905c2ef5344123054f24.

The Azure fixes for the GetQueryResultCountAsync header have been deployed several weeks ago and should be widely available now. This reverts the fix so we can once again get accurate work item counts when the count is >25. 

The referenced PR was never intended to be a permanent solution and was just to get widgets working again until the Azure fix was deployed and propagated to most/all environments.
 
## References and relevant issues
Revert of #156 

## Detailed description of the pull request / Additional comments

## Validation steps performed

* Built and deployed and tested Query List and Query Tiles with large work item count.
* Verified that the Tiles and List widget works as expected without errors.
* Verified the tile count is correct for large result queries (">25" is gone, replaced with actual count).

## PR checklist
- [x] Closes #179
- [x] Tests added/passed
- [x] Documentation updated
