### PR TITLE
Add ability to reset API key and better errors for QuickStart Playground

### DIFF
--- a/src/AzureExtension/AzureExtension.cs
+++ b/src/AzureExtension/AzureExtension.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.InteropServices;
 using AzureExtension.DevBox;
+using AzureExtension.Providers;
 using AzureExtension.QuickStartPlayground;
 using DevHomeAzureExtension.DeveloperId;
 using DevHomeAzureExtension.Providers;
@@ -42,6 +43,8 @@ public sealed class AzureExtension : IExtension
                 return _host.Services.GetService<DevBoxProvider>();
             case ProviderType.QuickStartProject:
                 return _host.Services.GetQuickStartProjectProviders();
+            case ProviderType.Settings:
+                return _host.Services.GetService<SettingsProvider>();
             default:
                 _log.Information($"Invalid provider: {providerType}");
                 return null;

--- a/src/AzureExtension/Providers/SettingsProvider.cs
+++ b/src/AzureExtension/Providers/SettingsProvider.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AzureExtension.Contracts;
+using Microsoft.Windows.DevHome.SDK;
+
+namespace AzureExtension.Providers;
+
+public sealed class SettingsProvider : ISettingsProvider
+{
+    private readonly IAICredentialService _aiCredentialService;
+
+    public string DisplayName => "Test Settings";
+
+    public SettingsProvider(IAICredentialService aiCredentialService)
+    {
+        _aiCredentialService = aiCredentialService;
+    }
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+    }
+
+    public AdaptiveCardSessionResult GetSettingsAdaptiveCardSession()
+    {
+        return new AdaptiveCardSessionResult(new SettingsUIController(_aiCredentialService));
+    }
+}

--- a/src/AzureExtension/Providers/SettingsProvider.cs
+++ b/src/AzureExtension/Providers/SettingsProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using AzureExtension.Contracts;
+using DevHomeAzureExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 
 namespace AzureExtension.Providers;
@@ -10,7 +11,7 @@ public sealed class SettingsProvider : ISettingsProvider
 {
     private readonly IAICredentialService _aiCredentialService;
 
-    public string DisplayName => "Test Settings";
+    public string DisplayName => Resources.GetResource(@"SettingsProviderDisplayName");
 
     public SettingsProvider(IAICredentialService aiCredentialService)
     {

--- a/src/AzureExtension/Providers/SettingsUIController.cs
+++ b/src/AzureExtension/Providers/SettingsUIController.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using AzureExtension.Contracts;
+using AzureExtension.QuickStartPlayground;
+using DevHomeAzureExtension.Helpers;
+using Microsoft.Windows.DevHome.SDK;
+using Serilog;
+using Windows.Foundation;
+
+namespace AzureExtension.Providers;
+
+internal sealed partial class SettingsUIController : IExtensionAdaptiveCardSession
+{
+    private static readonly Lazy<ILogger> _log = new(() => Serilog.Log.ForContext("SourceContext", nameof(SettingsUIController)));
+
+    private static readonly ILogger Log = _log.Value;
+
+    private readonly IAICredentialService _aiCredentialService;
+
+    private IExtensionAdaptiveCard? _extensionUI;
+
+    public SettingsUIController(IAICredentialService aiCredentialService)
+    {
+        _aiCredentialService = aiCredentialService;
+        _extensionUI = null;
+    }
+
+    public void Dispose()
+    {
+    }
+
+    public ProviderOperationResult Initialize(IExtensionAdaptiveCard extensionUI)
+    {
+        _extensionUI = extensionUI;
+        return UpdateCard();
+    }
+
+    private ProviderOperationResult UpdateCard()
+    {
+        try
+        {
+            var hasOpenAIKey = _aiCredentialService.GetCredentials(OpenAIDevContainerQuickStartProjectProvider.LoginId, OpenAIDevContainerQuickStartProjectProvider.LoginId) is not null;
+            SettingsAdaptiveCardInputPayload settingsAdaptiveCardInputPayload = new()
+            {
+                HasOpenAIKey = hasOpenAIKey,
+            };
+
+            return _extensionUI!.Update(
+                GetTemplate(),
+                JsonSerializer.Serialize(settingsAdaptiveCardInputPayload, SettingsAdaptiveCardPayloadSourceGeneration.Default.SettingsAdaptiveCardInputPayload),
+                string.Empty);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to update settings card");
+            return new ProviderOperationResult(ProviderOperationStatus.Failure, ex, ex.Message, ex.Message);
+        }
+    }
+
+    private static string GetTemplate()
+    {
+        var settingsUI = @"
+{
+    ""type"": ""AdaptiveCard"",
+    ""body"": [
+        {
+            ""type"": ""ActionSet"",
+            ""actions"": [
+                {
+                    ""type"": ""Action.Execute"",
+                    ""title"": """ + Resources.GetResource(@"QuickstartPlayground_OpenAI_ClearKey") + @""",
+                    ""id"": ""clearOpenAIKey"",
+                    ""isEnabled"": ""${HasOpenAIKey}""
+                }
+            ]
+        }
+    ],
+    ""$schema"": ""http://adaptivecards.io/schemas/adaptive-card.json"",
+    ""version"": ""1.5"",
+    ""minHeight"": ""200px""
+}
+";
+        return settingsUI;
+    }
+
+    public IAsyncOperation<ProviderOperationResult> OnAction(string action, string inputs)
+    {
+        return Task.Run(() =>
+        {
+            try
+            {
+                var adapativeCardPayload = JsonSerializer.Deserialize(action, SettingsAdaptiveCardPayloadSourceGeneration.Default.SettingsActionAdaptiveCardActionPayload);
+                if (adapativeCardPayload is not null)
+                {
+                    if (adapativeCardPayload.IsClearOpenAIKeyAction)
+                    {
+                        Log.Information("Clearing OpenAI key");
+                        _aiCredentialService.RemoveCredentials(OpenAIDevContainerQuickStartProjectProvider.LoginId, OpenAIDevContainerQuickStartProjectProvider.LoginId);
+                        return UpdateCard();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to clear OpenAI key");
+                return new ProviderOperationResult(ProviderOperationStatus.Failure, ex, ex.Message, ex.Message);
+            }
+
+            return new ProviderOperationResult(ProviderOperationStatus.Failure, null, string.Empty, "Unexpected state");
+        }).AsAsyncOperation();
+    }
+
+    internal sealed class SettingsActionAdaptiveCardActionPayload
+    {
+        public string? Id
+        {
+            get; set;
+        }
+
+        public bool IsClearOpenAIKeyAction => Id == "clearOpenAIKey";
+    }
+
+    internal sealed class SettingsAdaptiveCardInputPayload
+    {
+        public bool HasOpenAIKey { get; set; }
+    }
+
+    [JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+    [JsonSerializable(typeof(SettingsActionAdaptiveCardActionPayload))]
+    [JsonSerializable(typeof(SettingsAdaptiveCardInputPayload))]
+    internal sealed partial class SettingsAdaptiveCardPayloadSourceGeneration : JsonSerializerContext
+    {
+    }
+}

--- a/src/AzureExtension/QuickStartPlayground/DevContainerGenerationOperation.cs
+++ b/src/AzureExtension/QuickStartPlayground/DevContainerGenerationOperation.cs
@@ -50,7 +50,10 @@ public sealed class DevContainerGenerationOperation : IQuickStartProjectGenerati
 
                 if (recommendedLanguage.Contains("Rejected", StringComparison.OrdinalIgnoreCase))
                 {
-                    throw new InvalidDataException(recommendedLanguage);
+                    return new QuickStartProjectResult(
+                        new InvalidDataException(recommendedLanguage),
+                        recommendedLanguage,
+                        $"Requested rejected: '{recommendedLanguage}'");
                 }
 
                 // TelemetryProviderSingleton.Instance.LogGeneratedData("GetRecommendedLanguage", recommendedLanguage);
@@ -116,7 +119,10 @@ public sealed class DevContainerGenerationOperation : IQuickStartProjectGenerati
                 }
                 else
                 {
-                    throw new InvalidDataException(nameof(topDocFavoredLanguage));
+                    return new QuickStartProjectResult(
+                        new InvalidDataException(nameof(topDocFavoredLanguage)),
+                        Resources.GetResource(@"QuickstartPlayground_SampleFailureDuringProjectGeneration", recommendedLanguage),
+                        $"Failed to find similar sample for '{recommendedLanguage}'");
                 }
             }
             catch (Azure.RequestFailedException ex) when (string.Equals(ex.ErrorCode, "invalid_api_key", StringComparison.Ordinal))
@@ -128,7 +134,7 @@ public sealed class DevContainerGenerationOperation : IQuickStartProjectGenerati
             }
             catch (Exception ex)
             {
-                return new QuickStartProjectResult(ex, Resources.GetResource(@"QuickstartPlayground_FailureDuringProjectGeneration", currentStep), ex.Message);
+                return new QuickStartProjectResult(ex, Resources.GetResource(@"QuickstartPlayground_FailureDuringProjectGeneration", currentStep, ex.Message), ex.Message);
             }
 
             void ReportProgress(string step, uint progressValue, IExtensionAdaptiveCardSession2? dockerProgressAdapativeCardSession = null)

--- a/src/AzureExtension/QuickStartPlayground/OpenAIDevContainerQuickStartProjectProvider.cs
+++ b/src/AzureExtension/QuickStartPlayground/OpenAIDevContainerQuickStartProjectProvider.cs
@@ -15,7 +15,7 @@ public sealed partial class OpenAIDevContainerQuickStartProjectProvider : DevCon
 {
     private static readonly Uri _privacyUri = new("https://openai.com/policies/privacy-policy");
     private static readonly Uri _termsUri = new("https://openai.com/policies/terms-of-use");
-    private const string _loginId = "OpenAI";
+    internal const string LoginId = "OpenAI";
 
     public OpenAIDevContainerQuickStartProjectProvider(AzureOpenAIServiceFactory azureOpenAIServiceFactory, IInstalledAppsService installedAppsService)
         : base(
@@ -37,7 +37,7 @@ public sealed partial class OpenAIDevContainerQuickStartProjectProvider : DevCon
 
         public static QuickStartProjectAdaptiveCardResult GetAdaptiveCard(IAzureOpenAIService azureOpenAIService)
         {
-            if (azureOpenAIService.AICredentialService.GetCredentials(_loginId, _loginId) is not null)
+            if (azureOpenAIService.AICredentialService.GetCredentials(LoginId, LoginId) is not null)
             {
                 return null!;
             }
@@ -124,7 +124,7 @@ public sealed partial class OpenAIDevContainerQuickStartProjectProvider : DevCon
                             fixed (char* keyPtr = inputPayload.Key)
                             {
                                 SecureString secureString = new(keyPtr, inputPayload.Key.Length);
-                                _azureOpenAIService.AICredentialService.SaveCredentials(_loginId, _loginId, secureString);
+                                _azureOpenAIService.AICredentialService.SaveCredentials(LoginId, LoginId, secureString);
                             }
 
                             _azureOpenAIService.InitializeAIClient();

--- a/src/AzureExtension/Strings/en-US/Resources.resw
+++ b/src/AzureExtension/Strings/en-US/Resources.resw
@@ -664,12 +664,16 @@
     <comment>Locked="{0}" Error message shown when we failed to launch the {0} application for the generated Quickstart project.</comment>
   </data>
   <data name="QuickstartPlayground_FailureDuringProjectGeneration" xml:space="preserve">
-    <value>Failure when '{0}'</value>
-    <comment>Locked="{0}" Error message shown when we failed to generate the project where {0} mentions the step that failed.</comment>
+    <value>Failure when '{0}' with message '{1}'</value>
+    <comment>{Locked="{0}", "{1}"} Error message shown when we failed to generate the project where {0} mentions the step that failed and {1} mentions the exception message.</comment>
   </data>
   <data name="QuickstartPlayground_APIKeyFailureDuringProjectGeneration" xml:space="preserve">
     <value>Failure to authenticate with API Key when '{0}'</value>
     <comment>Locked="{0}" Error message shown when we failed with an API key error when generating the project where {0} mentions the step that failed.</comment>
+  </data>
+  <data name="QuickstartPlayground_SampleFailureDuringProjectGeneration" xml:space="preserve">
+    <value>Failed to find reference sample for '{0}'</value>
+    <comment>Locked="{0}" Error message shown when we failed to find the reference sample for the language mentioned by {0}</comment>
   </data>
   <data name="QuickstartPlayground_OpenAI_ClearKey" xml:space="preserve">
     <value>Clear OpenAI key</value>

--- a/src/AzureExtension/Strings/en-US/Resources.resw
+++ b/src/AzureExtension/Strings/en-US/Resources.resw
@@ -677,6 +677,10 @@
   </data>
   <data name="QuickstartPlayground_OpenAI_ClearKey" xml:space="preserve">
     <value>Clear OpenAI key</value>
-    <comment>>{Locked="OpenAI"} Text of button to clear OpenAI key.</comment>
+    <comment>{Locked="OpenAI"} Text of button to clear OpenAI key.</comment>
+  </data>
+  <data name="SettingsProviderDisplayName" xml:space="preserve">
+    <value>Settings</value>
+    <comment>Display name for settings page.</comment>
   </data>
 </root>

--- a/src/AzureExtension/Strings/en-US/Resources.resw
+++ b/src/AzureExtension/Strings/en-US/Resources.resw
@@ -670,5 +670,9 @@
   <data name="QuickstartPlayground_APIKeyFailureDuringProjectGeneration" xml:space="preserve">
     <value>Failure to authenticate with API Key when '{0}'</value>
     <comment>Locked="{0}" Error message shown when we failed with an API key error when generating the project where {0} mentions the step that failed.</comment>
-  </data>	
+  </data>
+  <data name="QuickstartPlayground_OpenAI_ClearKey" xml:space="preserve">
+    <value>Clear OpenAI key</value>
+    <comment>>{Locked="OpenAI"} Text of button to clear OpenAI key.</comment>
+  </data>
 </root>

--- a/src/AzureExtensionServer/Package.appxmanifest
+++ b/src/AzureExtensionServer/Package.appxmanifest
@@ -45,6 +45,7 @@
                   <Repository />
                   <ComputeSystem />
                   <QuickStartProject />
+                  <Settings />
                 </SupportedInterfaces>
               </DevHomeProvider>
             </uap3:Properties>

--- a/src/AzureExtensionServer/Program.cs
+++ b/src/AzureExtensionServer/Program.cs
@@ -4,6 +4,7 @@
 using AzureExtension.Contracts;
 using AzureExtension.DevBox;
 using AzureExtension.DevBox.Models;
+using AzureExtension.Providers;
 using AzureExtension.QuickStartPlayground;
 using AzureExtension.Services.DevBox;
 using DevHomeAzureExtension.DataModel;
@@ -236,6 +237,9 @@ public sealed class Program
             {
                 // Logging
                 services.AddLogging(builder => builder.AddSerilog(dispose: true));
+
+                // Settings
+                services.AddTransient<SettingsProvider>();
 
                 // Dev Box
                 services.AddHttpClient();


### PR DESCRIPTION
## Summary of the pull request

- Added a settings provider to allow clearing of the OpenAI API key when one is set
- Improved error handing during project generation with more specific messages for rejected requests and when sample is not found.

## References and relevant issues

## Detailed description of the pull request / Additional comments

![image](https://github.com/microsoft/DevHomeAzureExtension/assets/1691134/951101f5-7da8-4f8e-8f49-0784e5753bc1)

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
