### PR TITLE
Showing failures and log info in config flow; Fixing 'cloudpc-app' popup

### DIFF
--- a/src/AzureExtension/Contracts/IDevBoxManagementService.cs
+++ b/src/AzureExtension/Contracts/IDevBoxManagementService.cs
@@ -31,6 +31,15 @@ public interface IDevBoxManagementService
     public Task<DevBoxHttpsRequestResult> HttpsRequestToDataPlane(Uri webUri, IDeveloperId developerId, HttpMethod method, HttpContent? requestContent);
 
     /// <summary>
+    /// Makes an Https request to the azure data plane of the Dev Center.
+    /// </summary>
+    /// <param name="webUri">The Uri of the request.</param>
+    /// <param name="developerId">The DeveloperId associated with the request.</param>
+    /// <param name="method">The type of the the http request. E.g Get, Put, Post etc.</param>
+    /// <returns>The string result of the request.</returns>
+    public Task<string> HttpsRequestToDataPlaneWithRawResponse(Uri webUri, IDeveloperId developerId, HttpMethod method, HttpContent? requestContent = null);
+
+    /// <summary>
     /// Generates a list of objects that each contain a Dev Center project and the Dev Box pools associated with that project.
     /// </summary>
     /// <param name="projects">The Deserialized Json recieved from a rest api that returns a list of Dev Center projects.</param>

--- a/src/AzureExtension/Contracts/IDevBoxManagementService.cs
+++ b/src/AzureExtension/Contracts/IDevBoxManagementService.cs
@@ -37,7 +37,7 @@ public interface IDevBoxManagementService
     /// <param name="developerId">The DeveloperId associated with the request.</param>
     /// <param name="method">The type of the the http request. E.g Get, Put, Post etc.</param>
     /// <returns>The string result of the request.</returns>
-    public Task<string> HttpsRequestToDataPlaneWithRawResponse(Uri webUri, IDeveloperId developerId, HttpMethod method, HttpContent? requestContent = null);
+    public Task<string> HttpsRequestToDataPlaneRawResponse(Uri webUri, IDeveloperId developerId, HttpMethod method, HttpContent? requestContent = null);
 
     /// <summary>
     /// Generates a list of objects that each contain a Dev Center project and the Dev Box pools associated with that project.

--- a/src/AzureExtension/DevBox/Constants.cs
+++ b/src/AzureExtension/DevBox/Constants.cs
@@ -217,6 +217,11 @@ public static class Constants
     public const string DevBoxUnableToPerformOperationKey = "DevBox_UnableToPerformRequestedOperation";
 
     /// <summary>
+    /// Resource key for the error message to show with the log location for the configuration flow.
+    /// </summary>
+    public const string DevBoxCheckLogsKey = "DevBox_CheckLogs";
+
+    /// <summary>
     /// Resource key for the error message when Dev Boxes retrival failed.
     /// </summary>
     public const string RetrivalFailKey = "DevBox_RetrivalFailKey";

--- a/src/AzureExtension/DevBox/DevBoxInstance.cs
+++ b/src/AzureExtension/DevBox/DevBoxInstance.cs
@@ -669,9 +669,10 @@ public class DevBoxInstance : IComputeSystem, IComputeSystem2
         }).AsAsyncOperation();
     }
 
-    private string ValidateWindowsAppParameters()
+    private string ValidateWindowsAppAndItsParameters()
     {
         var isWindowsAppInstalled = _packagesService.IsPackageInstalled(Constants.WindowsAppPackageFamilyName);
+
         if (!isWindowsAppInstalled)
         {
             return "Windows App is not installed on the system";
@@ -690,11 +691,12 @@ public class DevBoxInstance : IComputeSystem, IComputeSystem2
     {
         return Task.Run(() =>
         {
-            var validationString = ValidateWindowsAppParameters();
-            if (!string.IsNullOrEmpty(validationString))
+            var errorString = ValidateWindowsAppAndItsParameters();
+
+            if (!string.IsNullOrEmpty(errorString))
             {
-                _log.Error(validationString);
-                return new ComputeSystemOperationResult(new InvalidDataException(), Resources.GetResource(Constants.DevBoxUnableToPerformOperationKey), validationString);
+                _log.Error(errorString);
+                return new ComputeSystemOperationResult(new InvalidDataException(), Resources.GetResource(Constants.DevBoxUnableToPerformOperationKey), errorString);
             }
 
             var exitcode = ExitCodeInvalid;
@@ -720,7 +722,7 @@ public class DevBoxInstance : IComputeSystem, IComputeSystem2
                 }
             }
 
-            var errorString = $"DoPinActionAsync with location {location} and action {pinAction} failed with exitcode: {exitcode}";
+            errorString = $"DoPinActionAsync with location {location} and action {pinAction} failed with exitcode: {exitcode}";
             _log.Error(errorString);
             return new ComputeSystemOperationResult(new NotSupportedException(), Resources.GetResource(Constants.DevBoxUnableToPerformOperationKey), errorString);
         }).AsAsyncOperation();
@@ -750,7 +752,7 @@ public class DevBoxInstance : IComputeSystem, IComputeSystem2
     {
         return Task.Run(() =>
         {
-            var validationString = ValidateWindowsAppParameters();
+            var validationString = ValidateWindowsAppAndItsParameters();
             if (!string.IsNullOrEmpty(validationString))
             {
                 _log.Error(validationString);

--- a/src/AzureExtension/DevBox/DevBoxInstance.cs
+++ b/src/AzureExtension/DevBox/DevBoxInstance.cs
@@ -671,7 +671,12 @@ public class DevBoxInstance : IComputeSystem, IComputeSystem2
 
     private string ValidateWindowsAppParameters()
     {
-        if (string.IsNullOrEmpty(WorkspaceId) || string.IsNullOrEmpty(DisplayName) || string.IsNullOrEmpty(Environment) || string.IsNullOrEmpty(Username))
+        var isWindowsAppInstalled = _packagesService.IsPackageInstalled(Constants.WindowsAppPackageFamilyName);
+        if (!isWindowsAppInstalled)
+        {
+            return "Windows App is not installed on the system";
+        }
+        else if (string.IsNullOrEmpty(WorkspaceId) || string.IsNullOrEmpty(DisplayName) || string.IsNullOrEmpty(Environment) || string.IsNullOrEmpty(Username))
         {
             return $"ValidateWindowsAppParameters failed with workspaceid={WorkspaceId} displayname={DisplayName} environment={Environment} username={Username}";
         }

--- a/src/AzureExtension/DevBox/DevBoxInstance.cs
+++ b/src/AzureExtension/DevBox/DevBoxInstance.cs
@@ -677,6 +677,13 @@ public class DevBoxInstance : IComputeSystem, IComputeSystem2
         {
             return "Windows App is not installed on the system";
         }
+
+        PackageVersion version = _packagesService.GetPackageInstalledVersion(Constants.WindowsAppPackageFamilyName);
+
+        if (!IsPackageVersionGreaterThan(version, MinimumWindowsAppVersion))
+        {
+            return "Older version of Windows App installed on the system";
+        }
         else if (string.IsNullOrEmpty(WorkspaceId) || string.IsNullOrEmpty(DisplayName) || string.IsNullOrEmpty(Environment) || string.IsNullOrEmpty(Username))
         {
             return $"ValidateWindowsAppParameters failed with workspaceid={WorkspaceId} displayname={DisplayName} environment={Environment} username={Username}";

--- a/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
+++ b/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
@@ -252,7 +252,8 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
                             // Find index of line with "Result" in it
                             // The error message is in the next line
                             var errorIndex = Array.FindIndex(logLines, x => x.Contains("Result")) + 1;
-                            var errorMessage = errorIndex > 0 ? logLines[errorIndex] : Resources.GetResource(Constants.DevBoxCheckLogsKey);
+                            var errorMessage = errorIndex >= 0 ? logLines[errorIndex] : Resources.GetResource(Constants.DevBoxCheckLogsKey);
+
 
                             // Make the result info to show in the UI
                             var resultInfo = new ConfigurationUnitResultInformation(

--- a/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
+++ b/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
@@ -252,10 +252,11 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
                             // Find index of line with "Result" in it
                             // The error message is in the next line
                             var errorIndex = Array.FindIndex(logLines, x => x.Contains("Result")) + 1;
+                            var errorMessage = errorIndex > 0 ? logLines[errorIndex] : Resources.GetResource(Constants.DevBoxCheckLogsKey);
 
                             // Make the result info to show in the UI
                             var resultInfo = new ConfigurationUnitResultInformation(
-                                new WingetConfigurationException("Runtime Failure"), logLines[errorIndex], string.Empty, ConfigurationUnitResultSource.UnitProcessing);
+                                new WingetConfigurationException("Runtime Failure"), errorMessage, string.Empty, ConfigurationUnitResultSource.UnitProcessing);
                             ConfigurationSetStateChangedEventArgs args = new(new(ConfigurationSetChangeEventType.UnitStateChanged, setState, ConfigurationUnitState.Completed, resultInfo, task));
                             ConfigurationSetStateChanged?.Invoke(this, args);
                         }

--- a/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
+++ b/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
@@ -254,7 +254,6 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
                             var errorIndex = Array.FindIndex(logLines, x => x.Contains("Result")) + 1;
                             var errorMessage = errorIndex >= 0 ? logLines[errorIndex] : Resources.GetResource(Constants.DevBoxCheckLogsKey);
 
-
                             // Make the result info to show in the UI
                             var resultInfo = new ConfigurationUnitResultInformation(
                                 new WingetConfigurationException("Runtime Failure"), errorMessage, string.Empty, ConfigurationUnitResultSource.UnitProcessing);

--- a/src/AzureExtension/Services/DevBox/DevBoxManagementService.cs
+++ b/src/AzureExtension/Services/DevBox/DevBoxManagementService.cs
@@ -50,7 +50,7 @@ public class DevBoxManagementService : IDevBoxManagementService
     }
 
     /// <inheritdoc cref="IDevBoxManagementService.HttpRequestToDataPlane"/>
-    public async Task<string> HttpsRequestToDataPlaneWithRawResponse(Uri webUri, IDeveloperId developerId, HttpMethod method, HttpContent? requestContent = null)
+    public async Task<string> HttpsRequestToDataPlaneRawResponse(Uri webUri, IDeveloperId developerId, HttpMethod method, HttpContent? requestContent = null)
     {
         var httpDataClient = _authService.GetDataPlaneClient(developerId);
         var result = await DevBoxHttpRequest(httpDataClient, webUri, developerId, method, requestContent);

--- a/src/AzureExtension/Services/DevBox/DevBoxManagementService.cs
+++ b/src/AzureExtension/Services/DevBox/DevBoxManagementService.cs
@@ -38,7 +38,15 @@ public class DevBoxManagementService : IDevBoxManagementService
     {
         var httpManagementClient = _authService.GetManagementClient(developerId);
         var result = await DevBoxHttpRequest(httpManagementClient, webUri, developerId, method, requestContent);
-        return new(JsonDocument.Parse(result.Content).RootElement, new DevBoxOperationResponseHeader(result.ResponseHeaders));
+        try
+        {
+            return new(JsonDocument.Parse(result.Content).RootElement, new DevBoxOperationResponseHeader(result.ResponseHeaders));
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, $"HttpsRequestToManagementPlane failed: Exception");
+            throw;
+        }
     }
 
     /// <inheritdoc cref="IDevBoxManagementService.HttpRequestToDataPlane"/>
@@ -46,7 +54,15 @@ public class DevBoxManagementService : IDevBoxManagementService
     {
         var httpDataClient = _authService.GetDataPlaneClient(developerId);
         var result = await DevBoxHttpRequest(httpDataClient, webUri, developerId, method, requestContent);
-        return new(JsonDocument.Parse(result.Content).RootElement, new DevBoxOperationResponseHeader(result.ResponseHeaders));
+        try
+        {
+            return new(JsonDocument.Parse(result.Content).RootElement, new DevBoxOperationResponseHeader(result.ResponseHeaders));
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, $"HttpsRequestToDataPlane failed: Exception");
+            throw;
+        }
     }
 
     /// <inheritdoc cref="IDevBoxManagementService.HttpRequestToDataPlane"/>

--- a/src/AzureExtension/Strings/en-US/Resources.resw
+++ b/src/AzureExtension/Strings/en-US/Resources.resw
@@ -670,5 +670,9 @@
   <data name="QuickstartPlayground_APIKeyFailureDuringProjectGeneration" xml:space="preserve">
     <value>Failure to authenticate with API Key when '{0}'</value>
     <comment>Locked="{0}" Error message shown when we failed with an API key error when generating the project where {0} mentions the step that failed.</comment>
-  </data>	
+  </data>
+  <data name="DevBox_CheckLogs" xml:space="preserve">
+    <value>Please check logs at C:\ProgramData\Microsoft\DevBoxAgent\Logs</value>
+    <comment>Shown for errors in config flow for Dev Boxes which don't have additional info</comment>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the issues
1. The configuration flow for Dev Boxes didn't show any failures since the API didn't support it. 
2. The extension launches a popup if Windows App isn't installed
![image](https://github.com/microsoft/DevHomeAzureExtension/assets/16077119/fde10dbe-941d-485c-8054-1f6c2bdd9a01)

## Detailed description of the pull request / Additional comments
1. The Dev Box configuration has been fixed and the API now correctly sends a "Failure" status. The extension has been changed accordingly to show the status on the UI. Additionally, a log API is called for the raw log, parsed and the relevant error line is now sent back to Dev Home to be shown on the UI.

![image](https://github.com/microsoft/DevHomeAzureExtension/assets/16077119/40959c3a-5fb3-4cf4-a8b4-78a7410c2bf1)
![image](https://github.com/microsoft/DevHomeAzureExtension/assets/16077119/26f7a7e2-798d-4dfb-904c-fbd93a76dd50)


2. The extension now checks to see if Windows App is installed before trying to try associated protocol launches

## Validation steps performed
Tested the configuration flow on various Dev Boxes

## PR checklist
- [ ] Closes #157 
- [ ] Closes #https://github.com/microsoft/devhome/issues/2902
- [ ] Tests added/passed
- [ ] Documentation updated
