### PR TITLE
Update Pinning operations and error messaging for Dev Box

### DIFF
--- a/src/AzureExtension/DevBox/Constants.cs
+++ b/src/AzureExtension/DevBox/Constants.cs
@@ -4,6 +4,8 @@
 using System.Text.Json;
 using AzureExtension.DevBox.DevBoxJsonToCsClasses;
 using AzureExtension.DevBox.Helpers;
+using DevHomeAzureExtension.Helpers;
+using Windows.Storage;
 
 namespace AzureExtension.DevBox;
 
@@ -216,6 +218,10 @@ public static class Constants
     /// </summary>
     public const string DevBoxUnableToPerformOperationKey = "DevBox_UnableToPerformRequestedOperation";
 
+    public const string DevBoxUnableToCheckStartMenuPinning = "DevBox_UnableToCheckStartMenuPinningStatus";
+
+    public const string DevBoxUnableToCheckTaskbarPinning = "DevBox_UnableToCheckTaskbarPinningStatus";
+
     /// <summary>
     /// Resource key for the error message when Dev Boxes retrival failed.
     /// </summary>
@@ -240,4 +246,16 @@ public static class Constants
     /// Windows App, used for remote connections, Package Family Name
     /// </summary>
     public const string WindowsAppPackageFamilyName = "MicrosoftCorporationII.Windows365_8wekyb3d8bbwe";
+
+    public static readonly string LogFolderName = "Logs";
+
+    private static readonly Lazy<string> _logFolderRoot = new(() => Path.Combine(ApplicationData.Current.TemporaryFolder.Path, LogFolderName));
+
+    public static readonly string LogFolderRoot = _logFolderRoot.Value;
+
+    public static readonly string OperationsDefaultErrorMsg = Resources.GetResource(DevBoxUnableToPerformOperationKey, LogFolderRoot);
+
+    public static readonly string StartMenuPinnedStatusErrorMsg = Resources.GetResource(DevBoxUnableToCheckStartMenuPinning, LogFolderRoot);
+
+    public static readonly string TaskbarPinnedStatusErrorMsg = Resources.GetResource(DevBoxUnableToCheckTaskbarPinning, LogFolderRoot);
 }

--- a/src/AzureExtension/DevBox/Constants.cs
+++ b/src/AzureExtension/DevBox/Constants.cs
@@ -249,7 +249,7 @@ public static class Constants
 
     public static readonly string LogFolderName = "Logs";
 
-    private static readonly Lazy<string> _logFolderRoot = new(() => Path.Combine(ApplicationData.Current.TemporaryFolder.Path, LogFolderName));
+    private static readonly Lazy<string> _logFolderRoot = new(GetLoggingPath);
 
     public static readonly string LogFolderRoot = _logFolderRoot.Value;
 
@@ -258,4 +258,17 @@ public static class Constants
     public static readonly string StartMenuPinnedStatusErrorMsg = Resources.GetResource(DevBoxUnableToCheckStartMenuPinning, LogFolderRoot);
 
     public static readonly string TaskbarPinnedStatusErrorMsg = Resources.GetResource(DevBoxUnableToCheckTaskbarPinning, LogFolderRoot);
+
+    private static string GetLoggingPath()
+    {
+        try
+        {
+            // This will always result in a returned value in non test scenarios. But will throw when run in a unit test as ApplicationData does not exist.
+            return Path.Combine(ApplicationData.Current.TemporaryFolder.Path, LogFolderName);
+        }
+        catch (Exception)
+        {
+            return string.Empty;
+        }
+    }
 }

--- a/src/AzureExtension/DevBox/DevBoxInstance.cs
+++ b/src/AzureExtension/DevBox/DevBoxInstance.cs
@@ -736,7 +736,7 @@ public class DevBoxInstance : IComputeSystem, IComputeSystem2
                 if (!string.IsNullOrEmpty(errorString))
                 {
                     _log.Error(errorString);
-                    throw new InvalidDataException(validationString);
+                    throw new InvalidDataException(errorString);
                 }
 
                 var exitcode = ExitCodeInvalid;

--- a/src/AzureExtension/DevBox/DevBoxInstance.cs
+++ b/src/AzureExtension/DevBox/DevBoxInstance.cs
@@ -681,11 +681,8 @@ public class DevBoxInstance : IComputeSystem, IComputeSystem2
 
     public IAsyncOperation<ComputeSystemOperationResult> ResumeAsync(string options)
     {
-        return Task.Run(() =>
-        {
-            StateChanged?.Invoke(this, ComputeSystemState.Starting);
-            return PerformRESTOperation(DevBoxActionToPerform.Start, HttpMethod.Post);
-        }).AsAsyncOperation();
+        StateChanged?.Invoke(this, ComputeSystemState.Starting);
+        return PerformRESTOperation(DevBoxActionToPerform.Start, HttpMethod.Post);
     }
 
     public IAsyncOperation<ComputeSystemOperationResult> SaveAsync(string options)
@@ -759,7 +756,7 @@ public class DevBoxInstance : IComputeSystem, IComputeSystem2
             {
                 _log.Error(ex, $"Unable to perform the pinning action for DevBox: {DisplayName}");
                 UpdateStateForUI();
-                return new ComputeSystemOperationResult(ex, Resources.GetResource(Constants.DevBoxUnableToPerformOperationKey), "Pinning action failed");
+                return new ComputeSystemOperationResult(ex, Constants.OperationsDefaultErrorMsg, "Pinning action failed");
             }
         }).AsAsyncOperation();
     }

--- a/src/AzureExtension/DevBox/DevBoxInstance.cs
+++ b/src/AzureExtension/DevBox/DevBoxInstance.cs
@@ -209,7 +209,7 @@ public class DevBoxInstance : IComputeSystem, IComputeSystem2
             return ComputeSystemOperations.Delete;
         }
 
-        ComputeSystemOperations operations = ComputeSystemOperations.Delete;
+        var operations = ComputeSystemOperations.Delete;
 
         switch (state)
         {

--- a/src/AzureExtension/DevBox/DevBoxProvider.cs
+++ b/src/AzureExtension/DevBox/DevBoxProvider.cs
@@ -65,7 +65,6 @@ public class DevBoxProvider : IComputeSystemProvider
     /// </summary>
     /// <param name="devBoxProject">Object with the properties of the project</param>
     /// <param name="devId">DeveloperID to be used for the authentication token service</param>
-    /// <param name="systems">List of valid dev box objects</param>
     private async Task ProcessAllDevBoxesInProjectAsync(DevBoxProject devBoxProject, IDeveloperId devId)
     {
         var devCenterUri = devBoxProject.Properties.DevCenterUri;
@@ -103,7 +102,7 @@ public class DevBoxProvider : IComputeSystemProvider
                 }
                 else
                 {
-                    newDevBoxInstance.LoadWindowsAppParameters();
+                    await newDevBoxInstance.LoadWindowsAppParameters();
                 }
 
                 devBoxes.Add(newDevBoxInstance);

--- a/src/AzureExtension/DevBox/DevBoxProvider.cs
+++ b/src/AzureExtension/DevBox/DevBoxProvider.cs
@@ -168,7 +168,7 @@ public class DevBoxProvider : IComputeSystemProvider
             }
             catch (Exception ex)
             {
-                var errorMessage = string.Empty;
+                var errorMessage = Constants.OperationsDefaultErrorMsg;
                 if (ex.InnerException != null && ex.InnerException.Message.Contains("Account has previously been signed out of this application"))
                 {
                     errorMessage = Resources.GetResource(Constants.RetrivalFailKey, developerId.LoginId) + Resources.GetResource(Constants.SessionExpiredKey);
@@ -231,7 +231,7 @@ public class DevBoxProvider : IComputeSystemProvider
             catch (Exception ex)
             {
                 _log.Error(ex, "Unable to get the adaptive card session for the provided developerId");
-                return new ComputeSystemAdaptiveCardResult(ex, ex.Message, ex.Message);
+                return new ComputeSystemAdaptiveCardResult(ex, Constants.OperationsDefaultErrorMsg, ex.Message);
             }
         }).GetAwaiter().GetResult();
     }
@@ -239,7 +239,7 @@ public class DevBoxProvider : IComputeSystemProvider
     public ComputeSystemAdaptiveCardResult CreateAdaptiveCardSessionForComputeSystem(IComputeSystem computeSystem, ComputeSystemAdaptiveCardKind sessionKind)
     {
         var exception = new NotImplementedException();
-        return new ComputeSystemAdaptiveCardResult(exception, Resources.GetResource(Constants.DevBoxMethodNotImplementedKey), exception.Message);
+        return new ComputeSystemAdaptiveCardResult(exception, Constants.OperationsDefaultErrorMsg, exception.Message);
     }
 
     private async Task<DevBoxProjects> GetDevBoxProjectsAsync(IDeveloperId developerId)

--- a/src/AzureExtension/Strings/en-US/Resources.resw
+++ b/src/AzureExtension/Strings/en-US/Resources.resw
@@ -412,8 +412,16 @@
     <comment>Error text to show the user when multiple operations are requested of the Dev Box provider without letting previous operations complete first.</comment>
   </data>
   <data name="DevBox_UnableToPerformRequestedOperation" xml:space="preserve">
-    <value>There was an error performing the requested operation. Error {0}</value>
-    <comment>Locked="{0}" Error text that we present the user when the Dev Box provider returns an error while attempting to performa user requested action. {0} is the error information received after attempting the call.</comment>
+    <value>There was an error performing the requested operation. For more information please view the log file {0}</value>
+    <comment>Locked="{0}" Error text that we present the user when the Dev Box provider returns an error while attempting to perform a user requested action. {0} is the location of the log file.</comment>
+  </data>
+  <data name="DevBox_UnableToCheckStartMenuPinningStatus" xml:space="preserve">
+    <value>Unable to confirm if the Dev Box is currently pinned to the start menu. For more information please view the log file {0}</value>
+    <comment>Error text that we present the user when the Dev Box provider is unable check whether or not the dev box is pinned to the start menu</comment>
+  </data>
+  <data name="DevBox_UnableToCheckTaskbarPinningStatus" xml:space="preserve">
+    <value>Unable to confirm if the Dev Box is currently pinned to the taskbar. For more information please view the log file {0}</value>
+    <comment>Error text that we present the user when the Dev Box provider is unable check whether or not the dev box is pinned to the taskbar</comment>
   </data>
   <data name="SelectionOptionsPrompt" xml:space="preserve">
     <value>Change Path</value>

--- a/src/AzureExtension/Strings/en-US/Resources.resw
+++ b/src/AzureExtension/Strings/en-US/Resources.resw
@@ -412,7 +412,7 @@
     <comment>Error text to show the user when multiple operations are requested of the Dev Box provider without letting previous operations complete first.</comment>
   </data>
   <data name="DevBox_UnableToPerformRequestedOperation" xml:space="preserve">
-    <value>There was an error performing the requested operation. For more information please view the log file {0}</value>
+    <value>There was an error performing the requested operation, for more information please view the log file {0}</value>
     <comment>Locked="{0}" Error text that we present the user when the Dev Box provider returns an error while attempting to perform a user requested action. {0} is the location of the log file.</comment>
   </data>
   <data name="DevBox_UnableToCheckStartMenuPinningStatus" xml:space="preserve">


### PR DESCRIPTION
## Summary of the pull request

**Note: Secondary PR in Dev Home repository**: https://github.com/microsoft/devhome/pull/2907

This PR makes sure that the pinning operation and errors are reflected in Dev Home. Currently When a pinning operation happens there is no status updates. Dev Home expects for every operation that the Compute System supports that there be a status update to inform the user something is occuring. E.g  "Starting".

Things this PR updates:
1. updates the supported operations for Dev Boxes based on the state.
2. Updates the error messages and points the user to the azure extension logs
3. Updates the "DoPinActionAsync" and "GetPinStatusAsync" methods to be within a try/catch.
4. Remove the `async void ` and used `async task` in the `LoadWindowsAppParameters` method as it was causing the Dev Boxes to randomly not contain the required WindowsAppParameters  by the time Dev Home called the `GetPinStatusAsync`.

Video showing me performing the pinning and unpinning operations:

https://github.com/microsoft/DevHomeAzureExtension/assets/105318831/91f735e8-d368-4571-b326-74ae8e961fa8



## References and relevant issues

## Detailed description of the pull request / Additional comments
Note: Due to the asynchrous calls for `GetPinStatusAsync`, when the operation to pin/upin the dev box is completed, the pin/pinned operations don't reset until `GetPinStatusAsync` is complete so there is a small delay when the operations update. We can work on trying to optimize this reset in a future PR.
## Validation steps performed

## PR checklist
- [x] Closes #microsoft/devhome/issues/2877
- [ ] Tests added/passed
- [ ] Documentation updated
