### PR TITLE
Add extra verbiage in the OpenAI setup instructions to help with configuration in Quickstart Playground

### DIFF
--- a/src/AzureExtension/QuickStartPlayground/OpenAIDevContainerQuickStartProjectProvider.cs
+++ b/src/AzureExtension/QuickStartPlayground/OpenAIDevContainerQuickStartProjectProvider.cs
@@ -78,6 +78,12 @@ public sealed partial class OpenAIDevContainerQuickStartProjectProvider : DevCon
             ""text"": """ + Resources.GetResource(@"QuickstartPlayground_OpenAI_AdaptiveCard_Text3") + @"""
         },
         {
+            ""type"": ""TextBlock"",
+            ""size"": ""Medium"",
+            ""text"": """ + Resources.GetResource(@"QuickstartPlayground_OpenAI_AdaptiveCard_Text4") + @""",
+            ""wrap"": true
+        },
+        {
             ""type"": ""Input.Text"",
             ""placeholder"": """ + Resources.GetResource(@"QuickstartPlayground_OpenAI_AdaptiveCard_APIKey_Input") + @""",
             ""tooltip"": """ + Resources.GetResource(@"QuickstartPlayground_OpenAI_AdaptiveCard_APIKey_Input") + @""",

--- a/src/AzureExtension/Strings/en-US/Resources.resw
+++ b/src/AzureExtension/Strings/en-US/Resources.resw
@@ -619,6 +619,10 @@
     <value>Please also see these [terms and conditions](https://openai.com/policies) for using OpenAI.</value>
     <comment>{Locked="https://openai.com/policies"} Third message in adaptive card to set OpenAI key.</comment>
   </data>
+  <data name="QuickstartPlayground_OpenAI_AdaptiveCard_Text4" xml:space="preserve">
+    <value>NOTE: You need to have available paid credits in your OpenAI account to use this feature. If you do not have credits, you will see an 'API key quota exceeded' error.</value>
+    <comment>Fourth message in adaptive card to set OpenAI key.</comment>
+  </data>
   <data name="QuickstartPlayground_OpenAI_AdaptiveCard_Image_AltText" xml:space="preserve">
     <value>Create OpenAI key</value>
     <comment>Alt text for image showing OpenAI API key UI.</comment>


### PR DESCRIPTION
## Summary of the pull request
This change includes some extra guidance for users to ensure they understand that an OpenAI account with paid credits is required for using the feature.

## References and relevant issues

## Detailed description of the pull request / Additional comments
PM requested some additional clarification in the setup instructions to ensure that users know that they need to have credits tied to their API key to use this feature. OpenAI allows users to create an OpenAI account and generate an API key without any backing credits, so users might think they can use those keys in this feature directly. The extra guidance will hopefully prevent this.  
 
## Validation steps performed
I visually verified that we see the new text in the adaptive card.

![image](https://github.com/microsoft/DevHomeAzureExtension/assets/8368026/c52a2ec3-9f17-42da-bac7-9154374c2c65)


## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
