### PR TITLE
Update how we get the Bloom thumbnail for dev box due errors that happen only when built outside of visual studio

### DIFF
--- a/src/AzureExtension/DevBox/Constants.cs
+++ b/src/AzureExtension/DevBox/Constants.cs
@@ -169,11 +169,7 @@ public static class Constants
     };
 
     /// <summary>
-    /// Location of the thumbnail that is shown for all Dev Boxes in the UI
-    /// </summary>
-
-    /// <summary>
-    /// Location of the provider icon.
+    /// Location of the provider icon and Dev Box bloom thumbnail icon.
     /// </summary>
     /// <remarks>
     /// We use different icon locations for different builds. Note these are ms-resource URIs, but are used by Dev Home to load the providers icon,

--- a/src/AzureExtension/DevBox/Constants.cs
+++ b/src/AzureExtension/DevBox/Constants.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using AzureExtension.DevBox.DevBoxJsonToCsClasses;
 using AzureExtension.DevBox.Helpers;
 using DevHomeAzureExtension.Helpers;
+using Windows.ApplicationModel;
 using Windows.Storage;
 
 namespace AzureExtension.DevBox;
@@ -170,7 +171,6 @@ public static class Constants
     /// <summary>
     /// Location of the thumbnail that is shown for all Dev Boxes in the UI
     /// </summary>
-    public const string ThumbnailURI = "ms-appx:///AzureExtension/Assets/DevBoxThumbnail.png";
 
     /// <summary>
     /// Location of the provider icon.
@@ -187,10 +187,13 @@ public static class Constants
     /// </remarks>
 #if CANARY_BUILD
     public const string ProviderIcon = "ms-resource://Microsoft.Windows.DevHomeAzureExtension.Canary/Files/AzureExtension/Assets/DevBoxProvider.png";
+    public const string ThumbnailURI = "ms-resource://Microsoft.Windows.DevHomeAzureExtension.Canary/Files/AzureExtension/Assets/DevBoxThumbnail.png";
 #elif STABLE_BUILD
     public const string ProviderIcon = "ms-resource://Microsoft.Windows.DevHomeAzureExtension/Files/AzureExtension/Assets/DevBoxProvider.png";
+    public const string ThumbnailURI = "ms-resource://Microsoft.Windows.DevHomeAzureExtension/Files/AzureExtension/Assets/DevBoxThumbnail.png";
 #else
     public const string ProviderIcon = "ms-resource://Microsoft.Windows.DevHomeAzureExtension.Dev/Files/AzureExtension/Assets/DevBoxProvider.png";
+    public const string ThumbnailURI = "ms-resource://Microsoft.Windows.DevHomeAzureExtension.Dev/Files/AzureExtension/Assets/DevBoxThumbnail.png";
 #endif
 
     /// <summary>
@@ -275,5 +278,13 @@ public static class Constants
         {
             return string.Empty;
         }
+    }
+
+    public static readonly Lazy<byte[]> ThumbnailInBytes = new(GetBloomThumbnailInBytes);
+
+    private static byte[] GetBloomThumbnailInBytes()
+    {
+        var fileLocationOfThumbnail = Resources.GetResourceFromPackage(Constants.ThumbnailURI, Package.Current.Id.FullName);
+        return File.ReadAllBytes(fileLocationOfThumbnail);
     }
 }

--- a/src/AzureExtension/DevBox/Constants.cs
+++ b/src/AzureExtension/DevBox/Constants.cs
@@ -284,7 +284,7 @@ public static class Constants
 
     private static byte[] GetBloomThumbnailInBytes()
     {
-        var fileLocationOfThumbnail = Resources.GetResourceFromPackage(Constants.ThumbnailURI, Package.Current.Id.FullName);
+        var fileLocationOfThumbnail = Resources.GetResourceFromPackage(ThumbnailURI, Package.Current.Id.FullName);
         return File.ReadAllBytes(fileLocationOfThumbnail);
     }
 }

--- a/src/AzureExtension/DevBox/DevBoxInstance.cs
+++ b/src/AzureExtension/DevBox/DevBoxInstance.cs
@@ -605,24 +605,12 @@ public class DevBoxInstance : IComputeSystem, IComputeSystem2
 
     public IAsyncOperation<ComputeSystemThumbnailResult> GetComputeSystemThumbnailAsync(string options)
     {
-        return Task.Run(async () =>
+        return Task.Run(() =>
         {
             try
             {
                 _log.Information($"Retrieving thumbnail for '{DisplayName}'");
-                var uri = new Uri(Constants.ThumbnailURI);
-                var storageFile = await StorageFile.GetFileFromApplicationUriAsync(uri);
-                var randomAccessStream = await storageFile.OpenReadAsync();
-
-                // Convert the stream to a byte array
-                var bytes = new byte[randomAccessStream.Size];
-
-                // safely convert ulong to uint
-                var maxSizeSafeUlongToUint = (uint)Math.Min(randomAccessStream.Size, uint.MaxValue);
-
-                await randomAccessStream.ReadAsync(bytes.AsBuffer(), maxSizeSafeUlongToUint, InputStreamOptions.None);
-
-                return new ComputeSystemThumbnailResult(bytes);
+                return new ComputeSystemThumbnailResult(Constants.ThumbnailInBytes.Value);
             }
             catch (Exception ex)
             {

--- a/src/AzureExtension/Helpers/Resources.cs
+++ b/src/AzureExtension/Helpers/Resources.cs
@@ -123,7 +123,7 @@ public static class Resources
     }
 
     /// <summary>
-    /// Gets the string of a ms-resource for a given package.
+    /// Gets a string or the absolute file path of an asset location within a package.
     /// </summary>
     /// <param name="resource">the ms-resource:// path to a resource in an app package's pri file.</param>
     /// <param name="packageFullName">the package containing the resource.</param>

--- a/src/AzureExtension/Helpers/Resources.cs
+++ b/src/AzureExtension/Helpers/Resources.cs
@@ -4,11 +4,15 @@
 using System.Globalization;
 using Microsoft.Windows.ApplicationModel.Resources;
 using Serilog;
+using Windows.Win32;
+using Windows.Win32.Foundation;
 
 namespace DevHomeAzureExtension.Helpers;
 
 public static class Resources
 {
+    private const int MaxBufferLength = 1024;
+
     private static ResourceLoader? _resourceLoader;
 
     public static string GetResource(string identifier, ILogger? log = null)
@@ -116,5 +120,27 @@ public static class Resources
             "Widget_Template/NotShownItems",
             "Widget_Template/ContentLoading",
         };
+    }
+
+    /// <summary>
+    /// Gets the string of a ms-resource for a given package.
+    /// </summary>
+    /// <param name="resource">the ms-resource:// path to a resource in an app package's pri file.</param>
+    /// <param name="packageFullName">the package containing the resource.</param>
+    /// <returns>The retrieved string represented by the resource key.</returns>
+    public static unsafe string GetResourceFromPackage(string resource, string packageFullName)
+    {
+        var indirectPathToResource = "@{" + packageFullName + "?" + resource + "}";
+        Span<char> outputBuffer = new char[MaxBufferLength];
+
+        fixed (char* outBufferPointer = outputBuffer)
+        {
+            fixed (char* resourcePathPointer = indirectPathToResource)
+            {
+                var res = PInvoke.SHLoadIndirectString(resourcePathPointer, new PWSTR(outBufferPointer), (uint)outputBuffer.Length);
+                res.ThrowOnFailure();
+                return new string(outputBuffer.TrimEnd('\0'));
+            }
+        }
     }
 }

--- a/src/AzureExtension/NativeMethods.txt
+++ b/src/AzureExtension/NativeMethods.txt
@@ -3,3 +3,4 @@ CredRead
 CredFree
 CredDelete
 WIN32_ERROR
+SHLoadIndirectString


### PR DESCRIPTION
## Summary of the pull request

When building the Azure extension in Visual studio there are no issues and the Dev Box providers bloom image is sent correctly to Dev Home. However, when building using the official build script and outside of Visual studio with `.\Build.cmd -Configuration release` trimming and ReadyToRun are enabled. I suspect that due to this combination somehow it is causing a `System.InvalidCastException: Specified cast is not valid.` error when we attempt to use the [StorageFile.OpenReadAsync](https://learn.microsoft.com/en-us/uwp/api/windows.storage.storagefile.openreadasync?view=winrt-22621) method.  This then returns a failure `ComputeSystemThumbnailResult` back to Dev Home who then shows the Dev Environments Default image instead of the Bloom image for Dev Boxes. 

This is the default image for environment:
<img width="64" alt="nonBloom-FromDesign" src="https://github.com/microsoft/DevHomeAzureExtension/assets/105318831/792704a2-f2d2-47ac-a321-8a8645285ba0">

but for Dev Boxes we should be showing this image:
<img width="64" alt="bloom image" src="https://github.com/microsoft/DevHomeAzureExtension/assets/105318831/ad1e4cb4-dc98-492d-954d-d295bedfd79f">


This is an issue because the Hyper-V extension also uses that default image. So to the user it will look like all the images are the same and there is no distinction. Due to this being build related, and we're so close to the cut off date for bug fixes, I do not want to add anything that could destablize anything else. So, This PR adds a work around where we get the location of the bloom image in the Azure extension package by using the same MRT [SHLoadIndirectString](`url`) api that we use in Dev Home to get images from other packages. I'm copying over the same function here:

https://github.com/microsoft/devhome/blob/b871d3dbdb60f7effcc0c5ff0efaefed2ff6a72f/common/Services/StringResource.cs#L72

and reusing so we can get the absolute path to the bloom image thats located in the azure extensions package, then use the .NET file system api `Storage.IO.File.ReadAllBytes` to convert the file to an array of bytes which we return back to dev home just like before.

Here is a video of how it looks **BEFORE** this change when you build the azure extension using the official build script. I'm using the current Dev Home canary to test this

https://github.com/microsoft/DevHomeAzureExtension/assets/105318831/2c1f9de6-0054-44bb-8a3b-5d1d8cb9381d



Here is a video of how it looks **AFTER** this change when you build the azure extension using the official build script. I'm using the current Dev Home canary to test this


https://github.com/microsoft/DevHomeAzureExtension/assets/105318831/91f6ec25-52c6-4259-b8b0-2dc1b474f345



## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

**Build using official azure extension build script and then used current Dev Home canary to confirm that the bloom image is now correctly being sent for Dev Boxes**


## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
