### PR TITLE
Add launch button, reduce wait, and better checking for status of Dev Boxes for config flow

### DIFF
--- a/src/AzureExtension/DevBox/DevBoxInstance.cs
+++ b/src/AzureExtension/DevBox/DevBoxInstance.cs
@@ -630,7 +630,7 @@ public class DevBoxInstance : IComputeSystem, IComputeSystem2
 
     public IApplyConfigurationOperation CreateApplyConfigurationOperation(string configuration)
     {
-        return new WingetConfigWrapper(configuration, DevBoxState.Uri, _devBoxManagementService, AssociatedDeveloperId, _log, GetState());
+        return new WingetConfigWrapper(configuration, DevBoxState.Uri, _devBoxManagementService, AssociatedDeveloperId, _log, GetState(), ConnectAsync);
     }
 
     // Unsupported operations

--- a/src/AzureExtension/DevBox/DevBoxInstance.cs
+++ b/src/AzureExtension/DevBox/DevBoxInstance.cs
@@ -630,8 +630,7 @@ public class DevBoxInstance : IComputeSystem, IComputeSystem2
 
     public IApplyConfigurationOperation CreateApplyConfigurationOperation(string configuration)
     {
-        var taskAPI = $"{DevBoxState.Uri}{Constants.CustomizationAPI}{DateTime.Now.ToFileTimeUtc()}?{Constants.APIVersion}";
-        return new WingetConfigWrapper(configuration, taskAPI, _devBoxManagementService, AssociatedDeveloperId, _log, GetState());
+        return new WingetConfigWrapper(configuration, DevBoxState.Uri, _devBoxManagementService, AssociatedDeveloperId, _log, GetState());
     }
 
     // Unsupported operations

--- a/src/AzureExtension/DevBox/DevBoxProvider.cs
+++ b/src/AzureExtension/DevBox/DevBoxProvider.cs
@@ -159,11 +159,12 @@ public class DevBoxProvider : IComputeSystemProvider
                 ArgumentNullException.ThrowIfNull(developerId);
                 ArgumentNullException.ThrowIfNullOrEmpty(developerId.LoginId);
 
-                _log.Information($"Attempting to retrieving all Dev Boxes for {developerId.LoginId}, at {DateTime.Now}");
+                var start = DateTime.Now;
+                _log.Information($"Attempting to retrieving all Dev Boxes for {developerId.LoginId}");
 
                 var computeSystems = await GetDevBoxesAsync(developerId);
 
-                _log.Information($"Successfully retrieved all Dev Boxes for {developerId.LoginId}, at {DateTime.Now}");
+                _log.Information($"Successfully retrieved all Dev Boxes for {developerId.LoginId}, in {DateTime.Now - start}");
                 return new ComputeSystemsResult(computeSystems);
             }
             catch (Exception ex)

--- a/src/AzureExtension/DevBox/Helpers/AdaptiveCardJSONToCSClass.cs
+++ b/src/AzureExtension/DevBox/Helpers/AdaptiveCardJSONToCSClass.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureExtension.DevBox.Helpers;
+
+public class AdaptiveCardJSONToCSClass
+{
+    public string? Data
+    {
+        get; set;
+    }
+
+    public string? Id
+    {
+        get; set;
+    }
+
+    public string? Title
+    {
+        get; set;
+    }
+
+    public string? Type
+    {
+        get; set;
+    }
+}

--- a/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
+++ b/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
@@ -4,6 +4,7 @@
 using System.Text;
 using System.Text.Json;
 using AzureExtension.Contracts;
+using AzureExtension.DevBox.DevBoxJsonToCsClasses;
 using AzureExtension.DevBox.Exceptions;
 using DevHomeAzureExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
@@ -63,7 +64,9 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
 
     private ApplyConfigurationSetResult _applyConfigurationSetResult = new(null, null);
 
-    private string _restAPI;
+    private string _taskAPI;
+
+    private string _baseAPI;
 
     private IDevBoxManagementService _managementService;
 
@@ -86,13 +89,14 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
 
     public WingetConfigWrapper(
         string configuration,
-        string taskAPI,
+        string baseAPI,
         IDevBoxManagementService devBoxManagementService,
         IDeveloperId associatedDeveloperId,
         Serilog.ILogger log,
         ComputeSystemState computeSystemState)
     {
-        _restAPI = taskAPI;
+        _baseAPI = baseAPI;
+        _taskAPI = $"{_baseAPI}{Constants.CustomizationAPI}{DateTime.Now.ToFileTimeUtc()}?{Constants.APIVersion}";
         _managementService = devBoxManagementService;
         _devId = associatedDeveloperId;
         _log = log;
@@ -239,7 +243,7 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
                             Thread.Sleep(TimeSpan.FromSeconds(15));
 
                             // Make the log API string : Remove the API version from the URI and add 'logs'
-                            var logURI = _restAPI.Substring(0, _restAPI.LastIndexOf('?'));
+                            var logURI = _taskAPI.Substring(0, _taskAPI.LastIndexOf('?'));
                             var id = response.Tasks[i].Id;
                             logURI += $"/logs/{id}?{Constants.APIVersion}";
 
@@ -306,19 +310,25 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
             {
                 if (_computeSystemState != ComputeSystemState.Running)
                 {
-                    throw new InvalidOperationException(Resources.GetResource(NotRunningFailedKey));
+                    // Check if the dev box might have been started in the meantime
+                    var stateRequest = await _managementService.HttpsRequestToDataPlane(new Uri(_baseAPI), _devId, HttpMethod.Get, null);
+                    var state = JsonSerializer.Deserialize<DevBoxMachineState>(stateRequest.JsonResponseRoot.ToString(), Constants.JsonOptions)!;
+                    if (state.PowerState != Constants.DevBoxPowerStates.Running)
+                    {
+                        throw new InvalidOperationException(Resources.GetResource(NotRunningFailedKey));
+                    }
                 }
 
                 _log.Information($"Applying config {_fullTaskJSON}");
 
                 HttpContent httpContent = new StringContent(_fullTaskJSON, Encoding.UTF8, "application/json");
-                var result = await _managementService.HttpsRequestToDataPlane(new Uri(_restAPI), _devId, HttpMethod.Put, httpContent);
+                var result = await _managementService.HttpsRequestToDataPlane(new Uri(_taskAPI), _devId, HttpMethod.Put, httpContent);
 
                 var setStatus = string.Empty;
                 while (setStatus != "Succeeded" && setStatus != "Failed" && setStatus != "ValidationFailed")
                 {
                     await Task.Delay(TimeSpan.FromSeconds(15));
-                    var poll = await _managementService.HttpsRequestToDataPlane(new Uri(_restAPI), _devId, HttpMethod.Get, null);
+                    var poll = await _managementService.HttpsRequestToDataPlane(new Uri(_taskAPI), _devId, HttpMethod.Get, null);
                     var rawResponse = poll.JsonResponseRoot.ToString();
                     var response = JsonSerializer.Deserialize<TaskJSONToCSClasses.BaseClass>(rawResponse, _taskJsonSerializerOptions);
                     setStatus = response?.Status;

--- a/src/AzureExtension/DevBox/Templates/WaitingForUserSessionTemplate.json
+++ b/src/AzureExtension/DevBox/Templates/WaitingForUserSessionTemplate.json
@@ -72,11 +72,13 @@
   "actions": [
     {
       "type": "Action.Execute",
+      "title": "${LaunchText}",
+      "id": "launchAction"
+    },
+    {
+      "type": "Action.Execute",
       "title": "${ResumeText}",
-      "id": "resumeAction",
-      "data": {
-        "id": "resumeAction"
-      }
+      "id": "resumeAction"
     }
   ]
 }

--- a/src/AzureExtension/Strings/en-US/Resources.resw
+++ b/src/AzureExtension/Strings/en-US/Resources.resw
@@ -699,4 +699,8 @@
     <value>Please check logs at C:\ProgramData\Microsoft\DevBoxAgent\Logs</value>
     <comment>Shown for errors in config flow for Dev Boxes which don't have additional info</comment>
   </data>
+  <data name="DevBox_AdaptiveCard_LaunchText" xml:space="preserve">
+    <value>Launch</value>
+    <comment>Text shown in the button to launch Dev Box.</comment>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the pull request

- Adds a launch button to directly login to a Dev Box in the case of "Waiting For Active User Session" while applying a configuration. 
- Reduces the wait time for a task to resume to complement the fix by the Dev Box team. It is now 30 seconds for normal logins but two minutes in the case of first time login initializations.
- Rechecks the status of a Dev Box before applying a configuration. Earlier if a Dev Box was started in the background during the configuration flow setup, the extension wasn't aware and failed the configuration task.

![image](https://github.com/microsoft/DevHomeAzureExtension/assets/16077119/3460fbf7-dfde-4d34-a557-be000ccd063a)

## Validation steps performed
Manually across multiple Dev Boxes

## PR checklist
- [ ] Closes #https://github.com/microsoft/devhome/issues/2992
- [ ] Closes #https://github.com/microsoft/devhome/issues/2976
- [ ] Tests added/passed
- [ ] Documentation updated
