### PR TITLE
Use TensorPrimitives.CosineSimilarity instead of bespoke implementation

### DIFF
--- a/src/AzureExtension/AzureExtension.csproj
+++ b/src/AzureExtension/AzureExtension.csproj
@@ -84,6 +84,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="System.Numerics.Tensors" Version="8.0.0" />
     <PackageReference Include="YamlDotNet" Version="15.1.2" />
   </ItemGroup>
 

--- a/src/AzureExtension/QuickStartPlayground/EmbeddingsCalc.cs
+++ b/src/AzureExtension/QuickStartPlayground/EmbeddingsCalc.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Globalization;
+using System.Numerics.Tensors;
 
 namespace AzureExtension.QuickStartPlayground;
 
@@ -12,19 +13,11 @@ namespace AzureExtension.QuickStartPlayground;
 /// </summary>
 public static class EmbeddingsCalc
 {
-    private static double DotProduct(ReadOnlyMemory<float> a, ReadOnlyMemory<float> b)
-    {
-        return Enumerable.Range(0, a.Length).Sum(i => a.Span[i] * b.Span[i]);
-    }
-
     private static double CalcCosineSimilarity(ReadOnlyMemory<float> a, ReadOnlyMemory<float> b)
     {
         try
         {
-            var dotProduct = DotProduct(a, b);
-            var magnitudeA = Math.Sqrt(DotProduct(a, a));
-            var magnitudeB = Math.Sqrt(DotProduct(b, b));
-            return dotProduct / (magnitudeA * magnitudeB);
+            return TensorPrimitives.CosineSimilarity(a.Span, b.Span);
         }
         catch (Exception)
         {


### PR DESCRIPTION
## Summary of the pull request

Replace a custom CosineSimilarity function with an optimized version from System.Numerics.Tensors.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
