### PR TITLE
Add logic to calculate how much space to allocate for completion requests

### DIFF
--- a/src/AzureExtension/AzureExtension.csproj
+++ b/src/AzureExtension/AzureExtension.csproj
@@ -68,6 +68,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.4" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.56.0" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.56.0" />
+    <PackageReference Include="Microsoft.ML.Tokenizers" Version="0.22.0-preview.24271.1" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.206-beta" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />

--- a/src/AzureExtension/QuickStartPlayground/AzureOpenAIService.cs
+++ b/src/AzureExtension/QuickStartPlayground/AzureOpenAIService.cs
@@ -21,9 +21,16 @@ public sealed class AzureOpenAIService : IAzureOpenAIService
 
     private readonly OpenAIEndpoint _endpoint;
 
-    private readonly int contextWindowMaxLength = 4096;
-    private readonly int contextWindowPadding = 100;
+    // We use a Microsoft-published library that implements OpenAI's TikToken algorithm to figure out how much space to
+    // allocate for the output.
     private readonly Tokenizer gpt3Tokenizer = Tokenizer.CreateTiktokenForModel("gpt-35-turbo-instruct");
+
+    // This is the publicly documented gpt-35-turbo-instruct context window length (shared between the input and output)
+    private readonly int contextWindowMaxLength = 4096;
+
+    // This is a fudge factor in case there is a discrepancy between the tokenizer's output and what the
+    // model will internally calculate.
+    private readonly int contextWindowPadding = 100;
 
     public AzureOpenAIService(IAICredentialService aiCredentialService, OpenAIEndpoint endpoint)
     {

--- a/src/AzureExtension/QuickStartPlayground/InstalledAppsService.cs
+++ b/src/AzureExtension/QuickStartPlayground/InstalledAppsService.cs
@@ -140,7 +140,7 @@ public class InstalledAppsService : IInstalledAppsService
             }
         }
 
-        _log.Information("${executableName} not found in PATH.");
+        _log.Information($"{executableName} not found in PATH.");
         return string.Empty;
     }
 


### PR DESCRIPTION
## Summary of the pull request
Our implementation doesn't try to 'right-size' the number of tokens that completion requests should use, which sometimes results in failures due to the total request being too large. This PR adds logic to calculate how many tokens to specify, which should hopefully mitigate this problem.

## References and relevant issues
Closes #194 

## Detailed description of the pull request / Additional comments
The model we are using (gpt-35-turbo-instruct) has a fixed context window (4096 tokens), which is shared across the input prompt and the response produced by the model. https://platform.openai.com/docs/models/gpt-3-5-turbo

Callers of the API can specify how many tokens the model can allocate to the response via the max tokens parameter. https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_tokens

We observed that with more complex or larger projects, responses weren't being produced due to our completion calls specifying a fixed max token amount (2000 tokens), so in cases where the prompt for a particular completion can be on the larger size, the request would be rejected since the model would observe that the total number of tokens exceeds its limit. 

OpenAI has a Python library called TikToken for calculating the number of tokens that a particular input string consumes when processed by a particular model family, and Microsoft has a managed implementation here: https://github.com/microsoft/Tokenizer

This PR takes advantage of this functionality to calculate how many tokens to allocate for the completion requests. 

## Validation steps performed
I used several test prompts that were previously failing (e.g., generating an Orleans project, generating a tic-tac-toe GUI app), and those no longer generate any errors.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
