### PR TITLE
Added filtering, sorting and location to Dev Box creation flow

### DIFF
--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxProjectProperties.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxProjectProperties.cs
@@ -16,4 +16,6 @@ public class DevBoxProjectProperties
     public string DevCenterId { get; set; } = string.Empty;
 
     public string Description { get; set; } = string.Empty;
+
+    public string DisplayName { get; set; } = string.Empty;
 }

--- a/src/AzureExtension/DevBox/Helpers/AbilitiesJSONToCSClasses.cs
+++ b/src/AzureExtension/DevBox/Helpers/AbilitiesJSONToCSClasses.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureExtension.DevBox.Helpers;
+
+// Example of a task JSON response that will be deserialized into the BaseClass class
+// {
+//  "abilitiesAsAdmin": [],
+//  "abilitiesAsDeveloper": [
+//    "CustomizeDevBoxes",
+//    "DeleteDevBoxes",
+//    "ManageDevBoxActions",
+//    "ReadDevBoxActions",
+//    "ReadDevBoxes",
+//    "ReadRemoteConnections",
+//    "StartDevBoxes",
+//    "StopDevBoxes",
+//    "WriteDevBoxes"
+//  ]
+// }
+//
+
+/// <summary>
+/// Represents the classes for the customization task JSON response.
+/// </summary>
+public class AbilitiesJSONToCSClasses
+{
+    public class BaseClass
+    {
+        public List<string> AbilitiesAsAdmin { get; set; } = new();
+
+        public List<string> AbilitiesAsDeveloper { get; set; } = new();
+    }
+}

--- a/src/AzureExtension/DevBox/Helpers/AbilitiesJSONToCSClasses.cs
+++ b/src/AzureExtension/DevBox/Helpers/AbilitiesJSONToCSClasses.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.Helpers;
+namespace DevHomeAzureExtension.DevBox.Helpers;
 
 // Example of a task JSON response that will be deserialized into the BaseClass class
 // {

--- a/src/AzureExtension/DevBox/Helpers/AbilitiesJSONToCSClasses.cs
+++ b/src/AzureExtension/DevBox/Helpers/AbilitiesJSONToCSClasses.cs
@@ -7,21 +7,15 @@ namespace AzureExtension.DevBox.Helpers;
 // {
 //  "abilitiesAsAdmin": [],
 //  "abilitiesAsDeveloper": [
-//    "CustomizeDevBoxes",
-//    "DeleteDevBoxes",
-//    "ManageDevBoxActions",
-//    "ReadDevBoxActions",
 //    "ReadDevBoxes",
-//    "ReadRemoteConnections",
-//    "StartDevBoxes",
-//    "StopDevBoxes",
-//    "WriteDevBoxes"
+//    "WriteDevBoxes",
+//    ...
 //  ]
 // }
 //
 
 /// <summary>
-/// Represents the classes for the customization task JSON response.
+/// Represents the class for the abilities JSON response.
 /// </summary>
 public class AbilitiesJSONToCSClasses
 {

--- a/src/AzureExtension/DevBox/Models/CreationAdaptiveCardSession.cs
+++ b/src/AzureExtension/DevBox/Models/CreationAdaptiveCardSession.cs
@@ -357,7 +357,7 @@ public class CreationAdaptiveCardSession : IExtensionAdaptiveCardSession2
                 var poolHardwareSpecs = Resources.GetResource("DevBox_PoolSubtitle", pool.HardwareProfile.VCPUs, pool.HardwareProfile.MemoryGB, pool.StorageProfile.OsDisk.DiskSizeGB);
                 var poolInfo = new JsonObject
                     {
-                        { "title", $"{pool.Name}" },
+                        { "title", $"{pool.Name} ({pool.Location})" },
                         { "subtitle", $"{poolHardwareSpecs}" },
                         { "value", $"{k}" },
                     };

--- a/src/AzureExtension/DevBox/Models/CreationAdaptiveCardSession.cs
+++ b/src/AzureExtension/DevBox/Models/CreationAdaptiveCardSession.cs
@@ -341,7 +341,7 @@ public class CreationAdaptiveCardSession : IExtensionAdaptiveCardSession2
             // Add information for the specific project to the project array
             var projectInfo = new JsonObject
                 {
-                    { "title", container.Project!.Name },
+                    { "title", container.Project!.Properties.DisplayName.Length > 0 ? container.Project!.Properties.DisplayName : container.Project!.Name },
                     { "value", $"{i}" },
                 };
 

--- a/src/AzureExtension/Services/DevBox/DevBoxManagementService.cs
+++ b/src/AzureExtension/Services/DevBox/DevBoxManagementService.cs
@@ -128,6 +128,7 @@ public class DevBoxManagementService : IDevBoxManagementService
         }
     }
 
+    // Filter out projects that the user does not have write access to
     private async Task<bool> FilterOutProjectAsync(DevBoxProject project, IDeveloperId developerId)
     {
         try
@@ -171,13 +172,13 @@ public class DevBoxManagementService : IDevBoxManagementService
 
         await Parallel.ForEachAsync(projects.Data!, async (project, token) =>
         {
+            if (await FilterOutProjectAsync(project, developerId))
+            {
+                return;
+            }
+
             try
             {
-                if (await FilterOutProjectAsync(project, developerId))
-                {
-                    return;
-                }
-
                 var properties = project.Properties;
                 var uriToRetrievePools = $"{properties.DevCenterUri}{DevBoxConstants.Projects}/{project.Name}/{DevBoxConstants.Pools}?{DevBoxConstants.APIVersion}";
                 var result = await HttpsRequestToDataPlane(new Uri(uriToRetrievePools), developerId, HttpMethod.Get);

--- a/src/AzureExtension/Services/DevBox/DevBoxManagementService.cs
+++ b/src/AzureExtension/Services/DevBox/DevBoxManagementService.cs
@@ -119,6 +119,23 @@ public class DevBoxManagementService : IDevBoxManagementService
         }
     }
 
+    private async Task<bool> FilterOutProjectAsync(DevBoxProject project, IDeveloperId developerId)
+    {
+        try
+        {
+            var uri = $"{project.Properties.DevCenterUri}{Constants.Projects}/{project.Name}/users/me/abilities?{Constants.APIVersion}";
+            var result = await HttpsRequestToDataPlane(new Uri(uri), developerId, HttpMethod.Get, null);
+            var rawResponse = result.JsonResponseRoot.ToString();
+            _log.Debug($"<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< Response from abilities: {rawResponse}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, $"Unable to get abilities for {project.Name}");
+            return false;
+        }
+    }
+
     /// <inheritdoc cref="IDevBoxManagementService.GetAllProjectsToPoolsMappingAsync"/>
     public async Task<List<DevBoxProjectAndPoolContainer>> GetAllProjectsToPoolsMappingAsync(DevBoxProjects projects, IDeveloperId developerId)
     {
@@ -139,6 +156,11 @@ public class DevBoxManagementService : IDevBoxManagementService
         {
             try
             {
+                if (await FilterOutProjectAsync(project, developerId))
+                {
+                    return;
+                }
+
                 var properties = project.Properties;
                 var uriToRetrievePools = $"{properties.DevCenterUri}{DevBoxConstants.Projects}/{project.Name}/{DevBoxConstants.Pools}?{DevBoxConstants.APIVersion}";
                 var result = await HttpsRequestToDataPlane(new Uri(uriToRetrievePools), developerId, HttpMethod.Get);
@@ -152,6 +174,9 @@ public class DevBoxManagementService : IDevBoxManagementService
                 _log.Error(ex, $"unable to get pools for {project.Name}");
             }
         });
+
+        // Sort the mapping by project name
+        projectsToPoolsMapping = new(projectsToPoolsMapping.OrderBy(x => x.Project?.Name));
 
         _projectAndPoolContainerMap.Add(uniqueUserId, projectsToPoolsMapping.ToList());
         return projectsToPoolsMapping.ToList();

--- a/src/AzureExtension/Services/DevBox/DevBoxManagementService.cs
+++ b/src/AzureExtension/Services/DevBox/DevBoxManagementService.cs
@@ -183,8 +183,14 @@ public class DevBoxManagementService : IDevBoxManagementService
                 var uriToRetrievePools = $"{properties.DevCenterUri}{DevBoxConstants.Projects}/{project.Name}/{DevBoxConstants.Pools}?{DevBoxConstants.APIVersion}";
                 var result = await HttpsRequestToDataPlane(new Uri(uriToRetrievePools), developerId, HttpMethod.Get);
                 var pools = JsonSerializer.Deserialize<DevBoxPoolRoot>(result.JsonResponseRoot.ToString(), DevBoxConstants.JsonOptions);
-                var container = new DevBoxProjectAndPoolContainer { Project = project, Pools = pools };
 
+                // Sort the pools by name
+                if (pools?.Value != null)
+                {
+                    pools.Value = new(pools.Value.OrderBy(x => x.Name));
+                }
+
+                var container = new DevBoxProjectAndPoolContainer { Project = project, Pools = pools };
                 projectsToPoolsMapping.Add(container);
             }
             catch (Exception ex)
@@ -194,7 +200,7 @@ public class DevBoxManagementService : IDevBoxManagementService
         });
 
         // Sort the mapping by project name
-        projectsToPoolsMapping = new(projectsToPoolsMapping.OrderBy(x => x.Project?.Name));
+        projectsToPoolsMapping = new(projectsToPoolsMapping.OrderByDescending(x => x.Project?.Name));
 
         _projectAndPoolContainerMap.Add(uniqueUserId, projectsToPoolsMapping.ToList());
         return projectsToPoolsMapping.ToList();

--- a/src/AzureExtension/Services/DevBox/DevBoxManagementService.cs
+++ b/src/AzureExtension/Services/DevBox/DevBoxManagementService.cs
@@ -133,7 +133,7 @@ public class DevBoxManagementService : IDevBoxManagementService
     {
         try
         {
-            var uri = $"{project.Properties.DevCenterUri}{Constants.Projects}/{project.Name}/users/me/abilities?{Constants.APIVersion}";
+            var uri = $"{project.Properties.DevCenterUri}{DevBoxConstants.Projects}/{project.Name}/users/me/abilities?{DevBoxConstants.APIVersion}";
             var result = HttpsRequestToDataPlane(new Uri(uri), developerId, HttpMethod.Get, null).Result;
             var rawResponse = result.JsonResponseRoot.ToString();
             var abilities = JsonSerializer.Deserialize<AbilitiesJSONToCSClasses.BaseClass>(rawResponse, _jsonOptions);


### PR DESCRIPTION
## Summary of the pull request
These changes relate to the Dev Box creation flow:
- Adds filtering out of projects, which a user has no write access to
Before:
<img width="292" alt="image" src="https://github.com/microsoft/DevHomeAzureExtension/assets/16077119/732a9fea-8dde-487c-b05d-d861ae0b284f">

After: 
<img width="295" alt="image" src="https://github.com/microsoft/DevHomeAzureExtension/assets/16077119/745e6077-f4de-4af5-8631-06b45f588deb">

- Adds locations beside the name of the pools
- Add sorting to the list of pools presented (not shown in the old screenshot above)

## PR checklist
- [x] Closes #https://github.com/microsoft/devhome/issues/2775
- [x] Closes #https://github.com/microsoft/devhome/issues/3129
- [x] Closes #https://github.com/microsoft/devhome/issues/3141
