### PR TITLE
Consolate on DevHomeAzureExtension namespace

### DIFF
--- a/src/AzureExtension/AzureExtension.cs
+++ b/src/AzureExtension/AzureExtension.cs
@@ -2,11 +2,10 @@
 // Licensed under the MIT License.
 
 using System.Runtime.InteropServices;
-using AzureExtension.DevBox;
-using AzureExtension.Providers;
-using AzureExtension.QuickStartPlayground;
+using DevHomeAzureExtension.DevBox;
 using DevHomeAzureExtension.DeveloperId;
 using DevHomeAzureExtension.Providers;
+using DevHomeAzureExtension.QuickStartPlayground;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Windows.DevHome.SDK;

--- a/src/AzureExtension/Contracts/IAICredentialService.cs
+++ b/src/AzureExtension/Contracts/IAICredentialService.cs
@@ -3,7 +3,7 @@
 
 using System.Security;
 
-namespace AzureExtension.Contracts;
+namespace DevHomeAzureExtension.Contracts;
 
 public interface IAICredentialService
 {

--- a/src/AzureExtension/Contracts/IArmTokenService.cs
+++ b/src/AzureExtension/Contracts/IArmTokenService.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Windows.DevHome.SDK;
 
-namespace AzureExtension.Contracts;
+namespace DevHomeAzureExtension.Contracts;
 
 // ARMTokenService is a service that provides an Azure Resource Manager (ARM) token.
 public interface IArmTokenService

--- a/src/AzureExtension/Contracts/IAzureOpenAIService.cs
+++ b/src/AzureExtension/Contracts/IAzureOpenAIService.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.Contracts;
+namespace DevHomeAzureExtension.Contracts;
 
 public enum OpenAIEndpoint
 {

--- a/src/AzureExtension/Contracts/IDataTokenService.cs
+++ b/src/AzureExtension/Contracts/IDataTokenService.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Windows.DevHome.SDK;
 
-namespace AzureExtension.Contracts;
+namespace DevHomeAzureExtension.Contracts;
 
 public interface IDataTokenService
 {

--- a/src/AzureExtension/Contracts/IDevBoxAuthService.cs
+++ b/src/AzureExtension/Contracts/IDevBoxAuthService.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Windows.DevHome.SDK;
 
-namespace AzureExtension.Contracts;
+namespace DevHomeAzureExtension.Contracts;
 
 public interface IDevBoxAuthService
 {

--- a/src/AzureExtension/Contracts/IDevBoxCreationManager.cs
+++ b/src/AzureExtension/Contracts/IDevBoxCreationManager.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.DevBox;
-using AzureExtension.DevBox.Models;
+using DevHomeAzureExtension.DevBox;
+using DevHomeAzureExtension.DevBox.Models;
 using Microsoft.Windows.DevHome.SDK;
 
-namespace AzureExtension.Contracts;
+namespace DevHomeAzureExtension.Contracts;
 
 public interface IDevBoxCreationManager
 {

--- a/src/AzureExtension/Contracts/IDevBoxManagementService.cs
+++ b/src/AzureExtension/Contracts/IDevBoxManagementService.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using AzureExtension.DevBox.DevBoxJsonToCsClasses;
-using AzureExtension.DevBox.Models;
+using DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
+using DevHomeAzureExtension.DevBox.Models;
 using Microsoft.Windows.DevHome.SDK;
 
-namespace AzureExtension.Contracts;
+namespace DevHomeAzureExtension.Contracts;
 
 public interface IDevBoxManagementService
 {

--- a/src/AzureExtension/Contracts/IDevBoxOperationWatcher.cs
+++ b/src/AzureExtension/Contracts/IDevBoxOperationWatcher.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.DevBox;
-using AzureExtension.DevBox.Models;
+using DevHomeAzureExtension.DevBox;
+using DevHomeAzureExtension.DevBox.Models;
 using Microsoft.Windows.DevHome.SDK;
 
-namespace AzureExtension.Contracts;
+namespace DevHomeAzureExtension.Contracts;
 
 /// <summary>
 /// Interface used to watch Dev Box operations asynchronously that take place in the Dev Center.

--- a/src/AzureExtension/Contracts/IInstalledAppsService.cs
+++ b/src/AzureExtension/Contracts/IInstalledAppsService.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.Contracts;
+namespace DevHomeAzureExtension.Contracts;
 
 public interface IInstalledAppsService
 {

--- a/src/AzureExtension/Contracts/IPackagesService.cs
+++ b/src/AzureExtension/Contracts/IPackagesService.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.Contracts;
+namespace DevHomeAzureExtension.Contracts;
 
 using Windows.ApplicationModel;
 

--- a/src/AzureExtension/Contracts/ITimeSpanService.cs
+++ b/src/AzureExtension/Contracts/ITimeSpanService.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.DevBox;
+using DevHomeAzureExtension.DevBox;
 
-namespace AzureExtension.Contracts;
+namespace DevHomeAzureExtension.Contracts;
 
 /// <summary>
 /// Interface that an operation watcher can use to get the time span based on the action to perform.

--- a/src/AzureExtension/DevBox/Constants.cs
+++ b/src/AzureExtension/DevBox/Constants.cs
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using AzureExtension.DevBox.DevBoxJsonToCsClasses;
-using AzureExtension.DevBox.Helpers;
+using DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
+using DevHomeAzureExtension.DevBox.Helpers;
 using DevHomeAzureExtension.Helpers;
 using Windows.ApplicationModel;
 using Windows.Storage;
 
-namespace AzureExtension.DevBox;
+namespace DevHomeAzureExtension.DevBox;
 
 public static class Constants
 {

--- a/src/AzureExtension/DevBox/DevBoxInstance.cs
+++ b/src/AzureExtension/DevBox/DevBoxInstance.cs
@@ -7,18 +7,18 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using System.Web;
-using AzureExtension.Contracts;
-using AzureExtension.DevBox.DevBoxJsonToCsClasses;
-using AzureExtension.DevBox.Helpers;
-using AzureExtension.DevBox.Models;
-using AzureExtension.Services.DevBox;
+using DevHomeAzureExtension.Contracts;
+using DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
+using DevHomeAzureExtension.DevBox.Helpers;
+using DevHomeAzureExtension.DevBox.Models;
 using DevHomeAzureExtension.Helpers;
+using DevHomeAzureExtension.Services.DevBox;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 using Windows.ApplicationModel;
 using Windows.Foundation;
 
-namespace AzureExtension.DevBox;
+namespace DevHomeAzureExtension.DevBox;
 
 public delegate DevBoxInstance DevBoxInstanceFactory(IDeveloperId developerId, DevBoxMachineState devBoxJson);
 

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxCreationPoolName.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxCreationPoolName.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// This is used to represent the json object that we send with the "create Dev Box" request.

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxHardwareProfile.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxHardwareProfile.cs
@@ -3,7 +3,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// Represents the HardwareProfile object within a response from a Dev Box rest API call.

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxImageReference.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxImageReference.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// Represents the ImageReference object within a response from a Dev Box rest API call.

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxLongRunningOperation.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxLongRunningOperation.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.DevBox.Models;
+using DevHomeAzureExtension.DevBox.Models;
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// https://azure.github.io/typespec-azure/docs/howtos/Azure%20Core/long-running-operations

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxMachineState.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxMachineState.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// This class represents the state of a DevBox machine. It is the class representation of

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxMachines.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxMachines.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// Represents the response from the Dev Center API for getting a list of DevBoxes

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxOperation.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxOperation.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Serialization;
-using AzureExtension.DevBox.Models;
+using DevHomeAzureExtension.DevBox.Models;
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// Represents the DevBoxOperation object within a response from a Dev Box rest API call.

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxOperationList.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxOperationList.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// Represents a list of DevBoxOperation object's within a response from a Dev Box rest API call.

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxOperationResult.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxOperationResult.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// Represents a DevBoxOperationResult object within a response from a Dev Box rest API call.

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxOsDisk.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxOsDisk.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// Represents a OsDisk object within a response from a Dev Box rest API call.

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxPool.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxPool.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// Represents a Pool object within a response from a Dev Box rest API call.

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxPoolRoot.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxPoolRoot.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// Represents a list of Pool object's within a response from a Dev Box rest API call.

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxPoolStopOnDisconnect.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxPoolStopOnDisconnect.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// Represents a StopOnDisconnect object within a response from a Dev Box rest API call.

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxProject.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxProject.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// Represents a DevBoxProject object within a response from a Dev Box rest API call.

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxProjectProperties.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxProjectProperties.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// Represents a ProjectProperties object within a response from a Dev Box rest API call.

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxProjects.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxProjects.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// Represents a List of DevBoxProject objects within a response from a Dev Box rest API call.

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxRemoteConnectionData.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxRemoteConnectionData.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// Represents the data returned from a request to retrieve the remote connection information for a Dev Box.

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxStorageProfile.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/DevBoxStorageProfile.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// Represents the StorageProfile object within a response from a Dev Box rest API call.

--- a/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/JsonSourceGenerationContext.cs
+++ b/src/AzureExtension/DevBox/DevBoxJsonToCsClasses/JsonSourceGenerationContext.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Serialization;
-using AzureExtension.DevBox.Models;
+using DevHomeAzureExtension.DevBox.Models;
 
-namespace AzureExtension.DevBox.DevBoxJsonToCsClasses;
+namespace DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
 /// <summary>
 /// Used to generate the source code for the classes that we deserialize Json to objects for the DevBox feature.

--- a/src/AzureExtension/DevBox/DevBoxProvider.cs
+++ b/src/AzureExtension/DevBox/DevBoxProvider.cs
@@ -4,15 +4,15 @@
 using System.Collections.Concurrent;
 using System.Text;
 using System.Text.Json;
-using AzureExtension.Contracts;
-using AzureExtension.DevBox.DevBoxJsonToCsClasses;
-using AzureExtension.DevBox.Models;
+using DevHomeAzureExtension.Contracts;
+using DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
+using DevHomeAzureExtension.DevBox.Models;
 using DevHomeAzureExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 using Windows.Foundation;
 
-namespace AzureExtension.DevBox;
+namespace DevHomeAzureExtension.DevBox;
 
 /// <summary>
 /// Implements the IComputeSystemProvider interface to provide DevBoxes as ComputeSystems.

--- a/src/AzureExtension/DevBox/Exceptions/DevBoxCreationException.cs
+++ b/src/AzureExtension/DevBox/Exceptions/DevBoxCreationException.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.Exceptions;
+namespace DevHomeAzureExtension.DevBox.Exceptions;
 
 public class DevBoxCreationException : Exception
 {

--- a/src/AzureExtension/DevBox/Exceptions/DevBoxNameInvalidException.cs
+++ b/src/AzureExtension/DevBox/Exceptions/DevBoxNameInvalidException.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.Exceptions;
+namespace DevHomeAzureExtension.DevBox.Exceptions;
 
 public class DevBoxNameInvalidException : Exception
 {

--- a/src/AzureExtension/DevBox/Exceptions/DevBoxOperationMonitorException.cs
+++ b/src/AzureExtension/DevBox/Exceptions/DevBoxOperationMonitorException.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.Exceptions;
+namespace DevHomeAzureExtension.DevBox.Exceptions;
 
 public class DevBoxOperationMonitorException : Exception
 {

--- a/src/AzureExtension/DevBox/Exceptions/DevBoxProjectNameInvalidException.cs
+++ b/src/AzureExtension/DevBox/Exceptions/DevBoxProjectNameInvalidException.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.Exceptions;
+namespace DevHomeAzureExtension.DevBox.Exceptions;
 
 public class DevBoxProjectNameInvalidException : Exception
 {

--- a/src/AzureExtension/DevBox/Exceptions/WingetConfigurationException.cs
+++ b/src/AzureExtension/DevBox/Exceptions/WingetConfigurationException.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.Exceptions;
+namespace DevHomeAzureExtension.DevBox.Exceptions;
 
 public class WingetConfigurationException : Exception
 {

--- a/src/AzureExtension/DevBox/Helpers/AdaptiveCardJSONToCSClass.cs
+++ b/src/AzureExtension/DevBox/Helpers/AdaptiveCardJSONToCSClass.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.Helpers;
+namespace DevHomeAzureExtension.DevBox.Helpers;
 
 public class AdaptiveCardJSONToCSClass
 {

--- a/src/AzureExtension/DevBox/Helpers/DevBoxOperationHelper.cs
+++ b/src/AzureExtension/DevBox/Helpers/DevBoxOperationHelper.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Windows.DevHome.SDK;
 
-namespace AzureExtension.DevBox.Helpers;
+namespace DevHomeAzureExtension.DevBox.Helpers;
 
 public static class DevBoxOperationHelper
 {

--- a/src/AzureExtension/DevBox/Helpers/DevCenterOperationStatusConverter.cs
+++ b/src/AzureExtension/DevBox/Helpers/DevCenterOperationStatusConverter.cs
@@ -3,9 +3,9 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using AzureExtension.DevBox.Models;
+using DevHomeAzureExtension.DevBox.Models;
 
-namespace AzureExtension.DevBox.Helpers;
+namespace DevHomeAzureExtension.DevBox.Helpers;
 
 /// <summary>
 /// Custom JSON converter for <see cref="DevCenterOperationStatus"/>.

--- a/src/AzureExtension/DevBox/Helpers/TaskJSONToCSClasses.cs
+++ b/src/AzureExtension/DevBox/Helpers/TaskJSONToCSClasses.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.Helpers;
+namespace DevHomeAzureExtension.DevBox.Helpers;
 
 // Example of a task JSON response that will be deserialized into the BaseClass class
 //    {

--- a/src/AzureExtension/DevBox/Helpers/TaskYAMLToCSClasses.cs
+++ b/src/AzureExtension/DevBox/Helpers/TaskYAMLToCSClasses.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace AzureExtension.DevBox.Helpers;
+namespace DevHomeAzureExtension.DevBox.Helpers;
 
 // Note: For every addition of a new resource type, the corresponding classes should be added here.
 // Example of a YAML file that will be deserialized

--- a/src/AzureExtension/DevBox/Helpers/WaitingForUserAdaptiveCardSession.cs
+++ b/src/AzureExtension/DevBox/Helpers/WaitingForUserAdaptiveCardSession.cs
@@ -9,7 +9,7 @@ using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 using Windows.Foundation;
 
-namespace AzureExtension.DevBox.Helpers;
+namespace DevHomeAzureExtension.DevBox.Helpers;
 
 public class WaitingForUserAdaptiveCardSession : IExtensionAdaptiveCardSession2, IDisposable
 {

--- a/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
+++ b/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
@@ -3,16 +3,16 @@
 
 using System.Text;
 using System.Text.Json;
-using AzureExtension.Contracts;
-using AzureExtension.DevBox.DevBoxJsonToCsClasses;
-using AzureExtension.DevBox.Exceptions;
+using DevHomeAzureExtension.Contracts;
+using DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
+using DevHomeAzureExtension.DevBox.Exceptions;
 using DevHomeAzureExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 using Windows.Foundation;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
-namespace AzureExtension.DevBox.Helpers;
+namespace DevHomeAzureExtension.DevBox.Helpers;
 
 public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
 {
@@ -32,7 +32,7 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
 
     public const string WingetTaskJsonTaskStart = @"{
             ""name"": ""winget"",
-			""runAs"": ""User"",
+            ""runAs"": ""User"",
             ""parameters"": {
                 ""inlineConfigurationBase64"": """;
 

--- a/src/AzureExtension/DevBox/Models/CreateComputeSystemOperation.cs
+++ b/src/AzureExtension/DevBox/Models/CreateComputeSystemOperation.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.Contracts;
-using AzureExtension.DevBox.Exceptions;
+using DevHomeAzureExtension.Contracts;
+using DevHomeAzureExtension.DevBox.Exceptions;
 using DevHomeAzureExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 using Windows.Foundation;
 
-namespace AzureExtension.DevBox.Models;
+namespace DevHomeAzureExtension.DevBox.Models;
 
 public delegate CreateComputeSystemOperation CreateComputeSystemOperationFactory(IDeveloperId developerId, DevBoxCreationParameters userOptions);
 

--- a/src/AzureExtension/DevBox/Models/CreationAdaptiveCardSession.cs
+++ b/src/AzureExtension/DevBox/Models/CreationAdaptiveCardSession.cs
@@ -9,7 +9,7 @@ using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 using Windows.Foundation;
 
-namespace AzureExtension.DevBox.Models;
+namespace DevHomeAzureExtension.DevBox.Models;
 
 public enum SessionState
 {

--- a/src/AzureExtension/DevBox/Models/DevBoxCreationParameters.cs
+++ b/src/AzureExtension/DevBox/Models/DevBoxCreationParameters.cs
@@ -4,7 +4,7 @@
 using System.Globalization;
 using System.Text;
 
-namespace AzureExtension.DevBox.Models;
+namespace DevHomeAzureExtension.DevBox.Models;
 
 /// <summary>
 /// These parameters are the parameters we'll expect to be passed in from Dev Home to create a Dev Box.

--- a/src/AzureExtension/DevBox/Models/DevBoxHttpsRequestResult.cs
+++ b/src/AzureExtension/DevBox/Models/DevBoxHttpsRequestResult.cs
@@ -3,7 +3,7 @@
 
 using System.Text.Json;
 
-namespace AzureExtension.DevBox.Models;
+namespace DevHomeAzureExtension.DevBox.Models;
 
 /// <summary>
 /// Represents the result of an HTTPS request result from the Dev Center. For Dev Box operations

--- a/src/AzureExtension/DevBox/Models/DevBoxOperationResponseHeader.cs
+++ b/src/AzureExtension/DevBox/Models/DevBoxOperationResponseHeader.cs
@@ -3,7 +3,7 @@
 
 using System.Net.Http.Headers;
 
-namespace AzureExtension.DevBox.Models;
+namespace DevHomeAzureExtension.DevBox.Models;
 
 /// <summary>
 /// Represents the header for a Dev Box long running operation. The Dev Box APIs run a Location and an Operation-Location

--- a/src/AzureExtension/DevBox/Models/DevBoxOperationWatcherTimer.cs
+++ b/src/AzureExtension/DevBox/Models/DevBoxOperationWatcherTimer.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.Services.DevBox;
+using DevHomeAzureExtension.Services.DevBox;
 using Windows.System.Threading;
 
-namespace AzureExtension.DevBox.Models;
+namespace DevHomeAzureExtension.DevBox.Models;
 
 /// <summary>
 /// Used to store information about a timer that is being stored by the <see cref="DevBoxOperationWatcher"/>.

--- a/src/AzureExtension/DevBox/Models/DevBoxProjectAndPoolContainer.cs
+++ b/src/AzureExtension/DevBox/Models/DevBoxProjectAndPoolContainer.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.DevBox.DevBoxJsonToCsClasses;
+using DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
 
-namespace AzureExtension.DevBox.Models;
+namespace DevHomeAzureExtension.DevBox.Models;
 
 /// <summary>
 /// Represents an object that contains both a DevBoxProject and a DevBoxPoolRoot.

--- a/src/AzureExtension/DevBox/Models/DevCenterOperationBase.cs
+++ b/src/AzureExtension/DevBox/Models/DevCenterOperationBase.cs
@@ -3,7 +3,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace AzureExtension.DevBox.Models;
+namespace DevHomeAzureExtension.DevBox.Models;
 
 /// <summary>
 /// The status of a DevCenter operation.

--- a/src/AzureExtension/Helpers/AzureRepositoryHierarchy.cs
+++ b/src/AzureExtension/Helpers/AzureRepositoryHierarchy.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using DevHomeAzureExtension.Client;
-using DevHomeAzureExtension.DeveloperId;
 using Microsoft.TeamFoundation.Core.WebApi;
 using Microsoft.VisualStudio.Services.Account.Client;
 using Microsoft.VisualStudio.Services.WebApi;
@@ -11,7 +10,7 @@ using Serilog;
 // In the past, an organization was known as an account.  Typedef to organization to make the code easier to read.
 using Organization = Microsoft.VisualStudio.Services.Account.Account;
 
-namespace AzureExtension.Helpers;
+namespace DevHomeAzureExtension.Helpers;
 
 /// <summary>
 /// Handles the hierarchy between organizations and projects.  Handles querying for both as well.
@@ -29,7 +28,7 @@ public class AzureRepositoryHierarchy
     // 1:N Organization to project.
     private readonly Dictionary<Organization, List<TeamProjectReference>> _organizationsAndProjects = new();
 
-    private readonly DeveloperId _developerId;
+    private readonly DeveloperId.DeveloperId _developerId;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureRepositoryHierarchy"/> class.
@@ -41,7 +40,7 @@ public class AzureRepositoryHierarchy
     /// Additionally, organizations and projects need to be fetched from the network.
     /// This class handles fetching the data, caching it, and searching it.
     /// </remarks>
-    public AzureRepositoryHierarchy(DeveloperId developerId)
+    public AzureRepositoryHierarchy(DeveloperId.DeveloperId developerId)
     {
         _developerId = developerId;
     }

--- a/src/AzureExtension/Providers/RepositoryProvider.cs
+++ b/src/AzureExtension/Providers/RepositoryProvider.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Security.Authentication;
-using AzureExtension.Helpers;
 using DevHomeAzureExtension.Client;
 using DevHomeAzureExtension.DeveloperId;
 using DevHomeAzureExtension.Helpers;

--- a/src/AzureExtension/Providers/SettingsProvider.cs
+++ b/src/AzureExtension/Providers/SettingsProvider.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.Contracts;
+using DevHomeAzureExtension.Contracts;
 using DevHomeAzureExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 
-namespace AzureExtension.Providers;
+namespace DevHomeAzureExtension.Providers;
 
 public sealed class SettingsProvider : ISettingsProvider
 {

--- a/src/AzureExtension/Providers/SettingsUIController.cs
+++ b/src/AzureExtension/Providers/SettingsUIController.cs
@@ -3,14 +3,14 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using AzureExtension.Contracts;
-using AzureExtension.QuickStartPlayground;
+using DevHomeAzureExtension.Contracts;
 using DevHomeAzureExtension.Helpers;
+using DevHomeAzureExtension.QuickStartPlayground;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 using Windows.Foundation;
 
-namespace AzureExtension.Providers;
+namespace DevHomeAzureExtension.Providers;
 
 internal sealed partial class SettingsUIController : IExtensionAdaptiveCardSession
 {

--- a/src/AzureExtension/QuickStartPlayground/AICredentialService.cs
+++ b/src/AzureExtension/QuickStartPlayground/AICredentialService.cs
@@ -5,12 +5,12 @@ using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
-using AzureExtension.Contracts;
+using DevHomeAzureExtension.Contracts;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.Security.Credentials;
 
-namespace AzureExtension.QuickStartPlayground;
+namespace DevHomeAzureExtension.QuickStartPlayground;
 
 public sealed class AICredentialService : IAICredentialService
 {

--- a/src/AzureExtension/QuickStartPlayground/AzureOpenAIDevContainerQuickStartProjectProvider.cs
+++ b/src/AzureExtension/QuickStartPlayground/AzureOpenAIDevContainerQuickStartProjectProvider.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.Contracts;
+using DevHomeAzureExtension.Contracts;
 using DevHomeAzureExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 
-namespace AzureExtension.QuickStartPlayground;
+namespace DevHomeAzureExtension.QuickStartPlayground;
 
 public sealed class AzureOpenAIDevContainerQuickStartProjectProvider : DevContainerQuickStartProjectProvider
 {

--- a/src/AzureExtension/QuickStartPlayground/AzureOpenAIService.cs
+++ b/src/AzureExtension/QuickStartPlayground/AzureOpenAIService.cs
@@ -5,12 +5,12 @@ using System.Diagnostics;
 using System.Reflection;
 using Azure;
 using Azure.AI.OpenAI;
-using AzureExtension.Contracts;
+using DevHomeAzureExtension.Contracts;
 using Microsoft.ML.Tokenizers;
 using Newtonsoft.Json;
 using Serilog;
 
-namespace AzureExtension.QuickStartPlayground;
+namespace DevHomeAzureExtension.QuickStartPlayground;
 
 public sealed class AzureOpenAIService : IAzureOpenAIService
 {

--- a/src/AzureExtension/QuickStartPlayground/Completions.cs
+++ b/src/AzureExtension/QuickStartPlayground/Completions.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.Contracts;
+using DevHomeAzureExtension.Contracts;
 
-namespace AzureExtension.QuickStartPlayground;
+namespace DevHomeAzureExtension.QuickStartPlayground;
 
 public static class Completions
 {

--- a/src/AzureExtension/QuickStartPlayground/DependencyUIController.cs
+++ b/src/AzureExtension/QuickStartPlayground/DependencyUIController.cs
@@ -4,12 +4,12 @@
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using AzureExtension.Contracts;
+using DevHomeAzureExtension.Contracts;
 using DevHomeAzureExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 using Windows.Foundation;
 
-namespace AzureExtension.QuickStartPlayground;
+namespace DevHomeAzureExtension.QuickStartPlayground;
 
 public sealed partial class DependencyUIController : IExtensionAdaptiveCardSession2
 {

--- a/src/AzureExtension/QuickStartPlayground/DevContainerGenerationOperation.cs
+++ b/src/AzureExtension/QuickStartPlayground/DevContainerGenerationOperation.cs
@@ -4,14 +4,14 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text.Json;
-using AzureExtension.Contracts;
+using DevHomeAzureExtension.Contracts;
 using DevHomeAzureExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 using Windows.Foundation;
 using Windows.Storage;
 
-namespace AzureExtension.QuickStartPlayground;
+namespace DevHomeAzureExtension.QuickStartPlayground;
 
 public sealed class DevContainerGenerationOperation : IQuickStartProjectGenerationOperation
 {

--- a/src/AzureExtension/QuickStartPlayground/DevContainerProjectFeedback.cs
+++ b/src/AzureExtension/QuickStartPlayground/DevContainerProjectFeedback.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Windows.DevHome.SDK;
 
-namespace AzureExtension.QuickStartPlayground;
+namespace DevHomeAzureExtension.QuickStartPlayground;
 
  public sealed class DevContainerProjectFeedback : IQuickStartProjectResultFeedbackHandler
 {

--- a/src/AzureExtension/QuickStartPlayground/DevContainerProjectHost.cs
+++ b/src/AzureExtension/QuickStartPlayground/DevContainerProjectHost.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 using DevHomeAzureExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 
-namespace AzureExtension.QuickStartPlayground;
+namespace DevHomeAzureExtension.QuickStartPlayground;
 
 public sealed class DevContainerProjectHost : IQuickStartProjectHost
 {

--- a/src/AzureExtension/QuickStartPlayground/DevContainerQuickStartProjectProvider.cs
+++ b/src/AzureExtension/QuickStartPlayground/DevContainerQuickStartProjectProvider.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.Contracts;
+using DevHomeAzureExtension.Contracts;
 using DevHomeAzureExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 using Windows.Storage;
 
-namespace AzureExtension.QuickStartPlayground;
+namespace DevHomeAzureExtension.QuickStartPlayground;
 
 public abstract class DevContainerQuickStartProjectProvider : IQuickStartProjectProvider
 {

--- a/src/AzureExtension/QuickStartPlayground/DockerProgressUIController.cs
+++ b/src/AzureExtension/QuickStartPlayground/DockerProgressUIController.cs
@@ -8,7 +8,7 @@ using System.Text.Json.Serialization;
 using Microsoft.Windows.DevHome.SDK;
 using Windows.Foundation;
 
-namespace AzureExtension.QuickStartPlayground;
+namespace DevHomeAzureExtension.QuickStartPlayground;
 
 public sealed partial class DockerProgressUIController : IExtensionAdaptiveCardSession2
 {

--- a/src/AzureExtension/QuickStartPlayground/DockerValidation.cs
+++ b/src/AzureExtension/QuickStartPlayground/DockerValidation.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics;
 using Windows.Storage;
 
-namespace AzureExtension.QuickStartPlayground;
+namespace DevHomeAzureExtension.QuickStartPlayground;
 
 public static class DockerValidation
 {

--- a/src/AzureExtension/QuickStartPlayground/EmbeddingsCalc.cs
+++ b/src/AzureExtension/QuickStartPlayground/EmbeddingsCalc.cs
@@ -4,7 +4,7 @@
 using System.Globalization;
 using System.Numerics.Tensors;
 
-namespace AzureExtension.QuickStartPlayground;
+namespace DevHomeAzureExtension.QuickStartPlayground;
 
 /// <summary>
 /// This class contains helper methods to perform vector database-like operations on the

--- a/src/AzureExtension/QuickStartPlayground/ExtensionInitializationUIController.cs
+++ b/src/AzureExtension/QuickStartPlayground/ExtensionInitializationUIController.cs
@@ -4,7 +4,7 @@
 using Microsoft.Windows.DevHome.SDK;
 using Windows.Foundation;
 
-namespace AzureExtension.QuickStartPlayground;
+namespace DevHomeAzureExtension.QuickStartPlayground;
 
 // This class serves as a wrapper around multiple adaptive cards which are displayed one after
 // another but don't know about each other.  After each adaptive card is done, the next is displayed.

--- a/src/AzureExtension/QuickStartPlayground/InstalledAppsService.cs
+++ b/src/AzureExtension/QuickStartPlayground/InstalledAppsService.cs
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics;
-using AzureExtension.Contracts;
+using DevHomeAzureExtension.Contracts;
 using Serilog;
 using Windows.Management.Deployment;
 using Windows.System.Inventory;
 
-namespace AzureExtension.QuickStartPlayground;
+namespace DevHomeAzureExtension.QuickStartPlayground;
 
 public class InstalledAppsService : IInstalledAppsService
 {

--- a/src/AzureExtension/QuickStartPlayground/OpenAIDevContainerQuickStartProjectProvider.cs
+++ b/src/AzureExtension/QuickStartPlayground/OpenAIDevContainerQuickStartProjectProvider.cs
@@ -4,12 +4,12 @@
 using System.Security;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using AzureExtension.Contracts;
+using DevHomeAzureExtension.Contracts;
 using DevHomeAzureExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 using Windows.Foundation;
 
-namespace AzureExtension.QuickStartPlayground;
+namespace DevHomeAzureExtension.QuickStartPlayground;
 
 public sealed partial class OpenAIDevContainerQuickStartProjectProvider : DevContainerQuickStartProjectProvider
 {

--- a/src/AzureExtension/QuickStartPlayground/ServiceExtensions.cs
+++ b/src/AzureExtension/QuickStartPlayground/ServiceExtensions.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.Contracts;
+using DevHomeAzureExtension.Contracts;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Windows.DevHome.SDK;
 
-namespace AzureExtension.QuickStartPlayground;
+namespace DevHomeAzureExtension.QuickStartPlayground;
 
 public static class ServiceExtensions
 {

--- a/src/AzureExtension/QuickStartPlayground/TrainingSample.cs
+++ b/src/AzureExtension/QuickStartPlayground/TrainingSample.cs
@@ -3,7 +3,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace AzureExtension.QuickStartPlayground;
+namespace DevHomeAzureExtension.QuickStartPlayground;
 
 public sealed class TrainingSample
 {

--- a/src/AzureExtension/Services/DevBox/ARMTokenService.cs
+++ b/src/AzureExtension/Services/DevBox/ARMTokenService.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.Contracts;
-using AzureExtension.DevBox;
+using DevHomeAzureExtension.Contracts;
 using DevHomeAzureExtension.DeveloperId;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
+using DevBoxConstants = DevHomeAzureExtension.DevBox.Constants;
 
-namespace AzureExtension.Services.DevBox;
+namespace DevHomeAzureExtension.Services.DevBox;
 
 /// <summary>
 /// Implementation of the Azure Resource Manager (ARM) token service.
@@ -26,7 +26,7 @@ public class ARMTokenService : IArmTokenService
             return string.Empty;
         }
 
-        var result = await AuthHelper.ObtainTokenForLoggedInDeveloperAccount(new string[] { Constants.ManagementPlaneScope }, devId.LoginId);
+        var result = await AuthHelper.ObtainTokenForLoggedInDeveloperAccount(new string[] { DevBoxConstants.ManagementPlaneScope }, devId.LoginId);
         return result?.AccessToken ?? string.Empty;
     }
 }

--- a/src/AzureExtension/Services/DevBox/AuthService.cs
+++ b/src/AzureExtension/Services/DevBox/AuthService.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 using System.Net.Http.Headers;
-using AzureExtension.Contracts;
+using DevHomeAzureExtension.Contracts;
 using Microsoft.Windows.DevHome.SDK;
 using Windows.ApplicationModel;
 
-namespace AzureExtension.Services.DevBox;
+namespace DevHomeAzureExtension.Services.DevBox;
 
 public class AuthService : IDevBoxAuthService
 {

--- a/src/AzureExtension/Services/DevBox/DataTokenService.cs
+++ b/src/AzureExtension/Services/DevBox/DataTokenService.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.Contracts;
-using AzureExtension.DevBox;
+using DevHomeAzureExtension.Contracts;
 using DevHomeAzureExtension.DeveloperId;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
+using DevBoxConstants = DevHomeAzureExtension.DevBox.Constants;
 
-namespace AzureExtension.Services.DevBox;
+namespace DevHomeAzureExtension.Services.DevBox;
 
 /// <summary>
 /// Implementation of Dev Box Data Plane token service.
@@ -28,7 +28,7 @@ public class DataTokenService : IDataTokenService
 
         try
         {
-            var result = await AuthHelper.ObtainTokenForLoggedInDeveloperAccount(new string[] { Constants.DataPlaneScope }, devId.LoginId);
+            var result = await AuthHelper.ObtainTokenForLoggedInDeveloperAccount(new string[] { DevBoxConstants.DataPlaneScope }, devId.LoginId);
             return result?.AccessToken ?? string.Empty;
         }
         catch (Exception e)

--- a/src/AzureExtension/Services/DevBox/DevBoxCreationManager.cs
+++ b/src/AzureExtension/Services/DevBox/DevBoxCreationManager.cs
@@ -2,15 +2,16 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using AzureExtension.Contracts;
-using AzureExtension.DevBox;
-using AzureExtension.DevBox.DevBoxJsonToCsClasses;
-using AzureExtension.DevBox.Models;
+using DevHomeAzureExtension.Contracts;
+using DevHomeAzureExtension.DevBox;
+using DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
+using DevHomeAzureExtension.DevBox.Models;
 using DevHomeAzureExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
+using DevBoxConstants = DevHomeAzureExtension.DevBox.Constants;
 
-namespace AzureExtension.Services.DevBox;
+namespace DevHomeAzureExtension.Services.DevBox;
 
 public class DevBoxCreationManager : IDevBoxCreationManager
 {
@@ -49,15 +50,15 @@ public class DevBoxCreationManager : IDevBoxCreationManager
         try
         {
             _log.Information($"Starting the create DevBox operation for new environment with new: {parameters.NewEnvironmentName}");
-            operation.UpdateProgress(Resources.GetResource(SendingCreationRequestProgressKey), Constants.IndefiniteProgress);
+            operation.UpdateProgress(Resources.GetResource(SendingCreationRequestProgressKey), DevBoxConstants.IndefiniteProgress);
 
             var result = await _devBoxManagementService.CreateDevBox(parameters, developerId);
-            operation.UpdateProgress(Resources.GetResource(CreationResponseReceivedProgressKey, parameters.NewEnvironmentName, parameters.ProjectName), Constants.IndefiniteProgress);
+            operation.UpdateProgress(Resources.GetResource(CreationResponseReceivedProgressKey, parameters.NewEnvironmentName, parameters.ProjectName), DevBoxConstants.IndefiniteProgress);
 
-            var devBoxState = JsonSerializer.Deserialize<DevBoxMachineState>(result.JsonResponseRoot.ToString(), Constants.JsonOptions)!;
+            var devBoxState = JsonSerializer.Deserialize<DevBoxMachineState>(result.JsonResponseRoot.ToString(), DevBoxConstants.JsonOptions)!;
             var devBox = _devBoxInstanceFactory(developerId, devBoxState);
 
-            operation.UpdateProgress(Resources.GetResource(DevCenterCreationStartedProgressKey, parameters.NewEnvironmentName, parameters.ProjectName), Constants.IndefiniteProgress);
+            operation.UpdateProgress(Resources.GetResource(DevCenterCreationStartedProgressKey, parameters.NewEnvironmentName, parameters.ProjectName), DevBoxConstants.IndefiniteProgress);
 
             var callback = DevCenterLongRunningOperationCallback(devBox);
 

--- a/src/AzureExtension/Services/DevBox/DevBoxManagementService.cs
+++ b/src/AzureExtension/Services/DevBox/DevBoxManagementService.cs
@@ -2,20 +2,19 @@
 // Licensed under the MIT License.
 
 using System.Collections.Concurrent;
-using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
-using AzureExtension.Contracts;
-using AzureExtension.DevBox;
-using AzureExtension.DevBox.DevBoxJsonToCsClasses;
-using AzureExtension.DevBox.Exceptions;
-using AzureExtension.DevBox.Models;
+using DevHomeAzureExtension.Contracts;
+using DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
+using DevHomeAzureExtension.DevBox.Exceptions;
+using DevHomeAzureExtension.DevBox.Models;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
+using DevBoxConstants = DevHomeAzureExtension.DevBox.Constants;
 
-namespace AzureExtension.Services.DevBox;
+namespace DevHomeAzureExtension.Services.DevBox;
 
 /// <summary>
 /// The DevBoxManagementService is responsible for making calls to the Azure Resource Graph API.
@@ -141,9 +140,9 @@ public class DevBoxManagementService : IDevBoxManagementService
             try
             {
                 var properties = project.Properties;
-                var uriToRetrievePools = $"{properties.DevCenterUri}{Constants.Projects}/{project.Name}/{Constants.Pools}?{Constants.APIVersion}";
+                var uriToRetrievePools = $"{properties.DevCenterUri}{DevBoxConstants.Projects}/{project.Name}/{DevBoxConstants.Pools}?{DevBoxConstants.APIVersion}";
                 var result = await HttpsRequestToDataPlane(new Uri(uriToRetrievePools), developerId, HttpMethod.Get);
-                var pools = JsonSerializer.Deserialize<DevBoxPoolRoot>(result.JsonResponseRoot.ToString(), Constants.JsonOptions);
+                var pools = JsonSerializer.Deserialize<DevBoxPoolRoot>(result.JsonResponseRoot.ToString(), DevBoxConstants.JsonOptions);
                 var container = new DevBoxProjectAndPoolContainer { Project = project, Pools = pools };
 
                 projectsToPoolsMapping.Add(container);
@@ -161,17 +160,17 @@ public class DevBoxManagementService : IDevBoxManagementService
     /// <inheritdoc cref="IDevBoxManagementService.CreateDevBox"/>
     public async Task<DevBoxHttpsRequestResult> CreateDevBox(DevBoxCreationParameters parameters, IDeveloperId developerId)
     {
-        if (!Regex.IsMatch(parameters.NewEnvironmentName, Constants.NameRegexPattern))
+        if (!Regex.IsMatch(parameters.NewEnvironmentName, DevBoxConstants.NameRegexPattern))
         {
             throw new DevBoxNameInvalidException($"Unable to create Dev Box due to Invalid Dev Box name: {parameters.NewEnvironmentName}");
         }
 
-        if (!Regex.IsMatch(parameters.ProjectName, Constants.NameRegexPattern))
+        if (!Regex.IsMatch(parameters.ProjectName, DevBoxConstants.NameRegexPattern))
         {
             throw new DevBoxProjectNameInvalidException($"Unable to create Dev Box due to Invalid project name: {parameters.ProjectName}");
         }
 
-        var uriToCreateDevBox = $"{parameters.DevCenterUri}{Constants.Projects}/{parameters.ProjectName}{Constants.DevBoxUserSegmentOfUri}/{parameters.NewEnvironmentName}?{Constants.APIVersion}";
+        var uriToCreateDevBox = $"{parameters.DevCenterUri}{DevBoxConstants.Projects}/{parameters.ProjectName}{DevBoxConstants.DevBoxUserSegmentOfUri}/{parameters.NewEnvironmentName}?{DevBoxConstants.APIVersion}";
         var contentJson = JsonSerializer.Serialize(new DevBoxCreationPoolName(parameters.PoolName));
         var content = new StringContent(contentJson, Encoding.UTF8, "application/json");
         return await HttpsRequestToDataPlane(new Uri(uriToCreateDevBox), developerId, HttpMethod.Put, content);

--- a/src/AzureExtension/Services/DevBox/DevBoxOperationWatcher.cs
+++ b/src/AzureExtension/Services/DevBox/DevBoxOperationWatcher.cs
@@ -2,16 +2,17 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using AzureExtension.Contracts;
-using AzureExtension.DevBox;
-using AzureExtension.DevBox.DevBoxJsonToCsClasses;
-using AzureExtension.DevBox.Exceptions;
-using AzureExtension.DevBox.Models;
+using DevHomeAzureExtension.Contracts;
+using DevHomeAzureExtension.DevBox;
+using DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
+using DevHomeAzureExtension.DevBox.Exceptions;
+using DevHomeAzureExtension.DevBox.Models;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 using Windows.System.Threading;
+using DevBoxConstants = DevHomeAzureExtension.DevBox.Constants;
 
-namespace AzureExtension.Services.DevBox;
+namespace DevHomeAzureExtension.Services.DevBox;
 
 /// <summary>
 /// Represents the status of a Dev Box provisioning operation.
@@ -76,7 +77,7 @@ public class DevBoxOperationWatcher : IDevBoxOperationWatcher
 
                     // Query the Dev Center for the status of the Dev Box operation.
                     var result = await _managementService.HttpsRequestToDataPlane(operationUri, developerId, HttpMethod.Get, null);
-                    var operation = JsonSerializer.Deserialize<DevCenterOperationBase>(result.JsonResponseRoot.ToString(), Constants.JsonOptions)!;
+                    var operation = JsonSerializer.Deserialize<DevCenterOperationBase>(result.JsonResponseRoot.ToString(), DevBoxConstants.JsonOptions)!;
 
                     // Invoke the call back so the original requester can handle the status update of the operation.
                     completionCallback(operation.Status);
@@ -137,12 +138,12 @@ public class DevBoxOperationWatcher : IDevBoxOperationWatcher
                     _log.Information($"Starting the provisioning monitor for Dev Box with Name: '{devBoxInstance.DisplayName}' , Id: '{devBoxInstance.Id}'");
 
                     // Query the Dev Center for the provisioning status of the Dev Box. This is needed for when the Dev Box was created outside of Dev Home.
-                    var devBoxUri = $"{devBoxInstance.DevBoxState.Uri}?{Constants.APIVersion}";
+                    var devBoxUri = $"{devBoxInstance.DevBoxState.Uri}?{DevBoxConstants.APIVersion}";
                     var result = await _managementService.HttpsRequestToDataPlane(new Uri(devBoxUri), developerId, HttpMethod.Get, null);
-                    var devBoxState = JsonSerializer.Deserialize<DevBoxMachineState>(result.JsonResponseRoot.ToString(), Constants.JsonOptions)!;
+                    var devBoxState = JsonSerializer.Deserialize<DevBoxMachineState>(result.JsonResponseRoot.ToString(), DevBoxConstants.JsonOptions)!;
 
                     // If the Dev Box is no longer being created, update the state for Dev Homes UI and end the timer.
-                    if (!(devBoxState.ProvisioningState == Constants.DevBoxProvisioningStates.Creating || devBoxState.ProvisioningState == Constants.DevBoxProvisioningStates.Provisioning))
+                    if (!(devBoxState.ProvisioningState == DevBoxConstants.DevBoxProvisioningStates.Creating || devBoxState.ProvisioningState == DevBoxConstants.DevBoxProvisioningStates.Provisioning))
                     {
                         _log.Information($"Dev Box provisioning now completed.");
                         devBoxInstance.ProvisioningMonitorCompleted(devBoxState, ProvisioningStatus.Succeeded);

--- a/src/AzureExtension/Services/DevBox/PackagesService.cs
+++ b/src/AzureExtension/Services/DevBox/PackagesService.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.Contracts;
+using DevHomeAzureExtension.Contracts;
 using Windows.ApplicationModel;
 
-namespace AzureExtension.Services.DevBox;
+namespace DevHomeAzureExtension.Services.DevBox;
 
 public class PackagesService : IPackagesService
 {

--- a/src/AzureExtension/Services/DevBox/TimeSpanService.cs
+++ b/src/AzureExtension/Services/DevBox/TimeSpanService.cs
@@ -1,17 +1,18 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.Contracts;
-using AzureExtension.DevBox;
+using DevHomeAzureExtension.Contracts;
+using DevHomeAzureExtension.DevBox;
+using DevBoxConstants = DevHomeAzureExtension.DevBox.Constants;
 
-namespace AzureExtension.Services.DevBox;
+namespace DevHomeAzureExtension.Services.DevBox;
 
 /// <summary>
 /// Service to provide time spans for different operations.
 /// </summary>
 public class TimeSpanService : ITimeSpanService
 {
-    public TimeSpan DevBoxOperationDeadline { get; private set; } = Constants.OperationDeadline;
+    public TimeSpan DevBoxOperationDeadline { get; private set; } = DevBoxConstants.OperationDeadline;
 
     /// <summary>
     /// Get the period interval based on the action to perform.
@@ -28,9 +29,9 @@ public class TimeSpanService : ITimeSpanService
         switch (actionToPerform)
         {
             case DevBoxActionToPerform.Create:
-                return Constants.ThreeMinutePeriod;
+                return DevBoxConstants.ThreeMinutePeriod;
             default:
-                return Constants.OneMinutePeriod;
+                return DevBoxConstants.OneMinutePeriod;
         }
     }
 }

--- a/src/AzureExtensionServer/Program.cs
+++ b/src/AzureExtensionServer/Program.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.Contracts;
-using AzureExtension.DevBox;
-using AzureExtension.DevBox.Models;
-using AzureExtension.Providers;
-using AzureExtension.QuickStartPlayground;
-using AzureExtension.Services.DevBox;
+using DevHomeAzureExtension.Contracts;
 using DevHomeAzureExtension.DataModel;
+using DevHomeAzureExtension.DevBox;
+using DevHomeAzureExtension.DevBox.Models;
 using DevHomeAzureExtension.DeveloperId;
+using DevHomeAzureExtension.Providers;
+using DevHomeAzureExtension.QuickStartPlayground;
+using DevHomeAzureExtension.Services.DevBox;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/test/AzureExtension/DevBox/ArmTestTokenService.cs
+++ b/test/AzureExtension/DevBox/ArmTestTokenService.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.Contracts;
+using DevHomeAzureExtension.Contracts;
 using Microsoft.Windows.DevHome.SDK;
 
-namespace AzureExtension.Test.DevBox;
+namespace DevHomeAzureExtension.Test.DevBox;
 
 public class ArmTestTokenService : IArmTokenService
 {

--- a/test/AzureExtension/DevBox/DataTestTokenService.cs
+++ b/test/AzureExtension/DevBox/DataTestTokenService.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.Contracts;
+using DevHomeAzureExtension.Contracts;
 using Microsoft.Windows.DevHome.SDK;
 
-namespace AzureExtension.Test.DevBox;
+namespace DevHomeAzureExtension.Test.DevBox;
 
 public class DataTestTokenService : IDataTokenService
 {

--- a/test/AzureExtension/DevBox/DevBoxTests.cs
+++ b/test/AzureExtension/DevBox/DevBoxTests.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using AzureExtension.DevBox;
-using AzureExtension.DevBox.DevBoxJsonToCsClasses;
-using AzureExtension.DevBox.Models;
-using AzureExtension.Test.DevBox;
+using DevHomeAzureExtension.DevBox;
+using DevHomeAzureExtension.DevBox.DevBoxJsonToCsClasses;
+using DevHomeAzureExtension.DevBox.Models;
+using DevHomeAzureExtension.Test.DevBox;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Windows.DevHome.SDK;
 

--- a/test/AzureExtension/DevBox/DevBoxTestsSetup.cs
+++ b/test/AzureExtension/DevBox/DevBoxTestsSetup.cs
@@ -3,11 +3,11 @@
 
 using System.Net;
 using System.Net.Http.Headers;
-using AzureExtension.Contracts;
-using AzureExtension.DevBox;
-using AzureExtension.DevBox.Models;
-using AzureExtension.Services.DevBox;
-using AzureExtension.Test.DevBox;
+using DevHomeAzureExtension.Contracts;
+using DevHomeAzureExtension.DevBox;
+using DevHomeAzureExtension.DevBox.Models;
+using DevHomeAzureExtension.Services.DevBox;
+using DevHomeAzureExtension.Test.DevBox;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Moq;

--- a/test/AzureExtension/DevBox/EmptyDeveloperId.cs
+++ b/test/AzureExtension/DevBox/EmptyDeveloperId.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Windows.DevHome.SDK;
 
-namespace AzureExtension.Test.DevBox;
+namespace DevHomeAzureExtension.Test.DevBox;
 
 public class EmptyDeveloperId : IDeveloperId
 {

--- a/test/AzureExtension/DevBox/TimeSpanServiceMock.cs
+++ b/test/AzureExtension/DevBox/TimeSpanServiceMock.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureExtension.Contracts;
-using AzureExtension.DevBox;
+using DevHomeAzureExtension.Contracts;
+using DevHomeAzureExtension.DevBox;
 
-namespace AzureExtension.Test.DevBox;
+namespace DevHomeAzureExtension.Test.DevBox;
 
 public class TimeSpanServiceMock : ITimeSpanService
 {

--- a/test/AzureExtension/DeveloperId/Mocks/MockAuthenticationSettings.cs
+++ b/test/AzureExtension/DeveloperId/Mocks/MockAuthenticationSettings.cs
@@ -3,7 +3,7 @@
 
 using DevHomeAzureExtension.DeveloperId;
 
-namespace AzureExtension.Test.DeveloperId.Mocks;
+namespace DevHomeAzureExtension.Test.DeveloperId.Mocks;
 
 public class MockAuthenticationSettings : IAuthenticationSettings
 {


### PR DESCRIPTION
## Summary of the pull request
Pulling out part of #229 to just do namespace changes and keep that PR smaller.
As @dkbennett wrote, "The default when creating a new class is `AzureExtension` namespace after the directory, but we actually use `DevHomeAzureExtension` namespace name with a shorter directory name to help reduce potential max-path issues. Some components were created using the default `AzureExtension` namespace and this was fixed."

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
