### PR TITLE
Fix program method logic.

### DIFF
--- a/src/AzureExtensionServer/Program.cs
+++ b/src/AzureExtensionServer/Program.cs
@@ -25,7 +25,7 @@ namespace DevHomeAzureExtension;
 public sealed class Program
 {
     [MTAThread]
-    public static void Main([System.Runtime.InteropServices.WindowsRuntime.ReadOnlyArray] string[] args)
+    public static async Task Main([System.Runtime.InteropServices.WindowsRuntime.ReadOnlyArray] string[] args)
     {
         // Setup Logging
         Environment.SetEnvironmentVariable("DEVHOME_LOGS_ROOT", ApplicationData.Current.TemporaryFolder.Path);
@@ -49,7 +49,7 @@ public sealed class Program
         if (!mainInstance.IsCurrent)
         {
             Log.Information($"Not main instance, redirecting.");
-            mainInstance.RedirectActivationToAsync(activationArgs).AsTask().Wait();
+            await mainInstance.RedirectActivationToAsync(activationArgs);
             notificationManager.Unregister();
             Log.CloseAndFlush();
             return;
@@ -85,7 +85,7 @@ public sealed class Program
             var d = activationArgs.Data as ILaunchActivatedEventArgs;
             var args = d?.Arguments.Split();
 
-            if (args?.Length > 0 && args[1] == "-RegisterProcessAsComServer")
+            if (args?.Length > 1 && args[1] == "-RegisterProcessAsComServer")
             {
                 Log.Information($"Activation COM Registration Redirect: {string.Join(' ', args.ToList())}");
                 HandleCOMServerActivation();


### PR DESCRIPTION
This PR fixes two issues identified in the program methods for the dev home extensions; first that the Main method needs to be async so that RedirectActivationToAsync call can be awaited and that an access of args[1] is correctly guarded.

This PR mimics https://github.com/microsoft/devhome/pull/3445.