### PR TITLE
Fix duplicate classIDs for different builds

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -20,7 +20,7 @@ parameters:
     - release
 
 variables:
-  MSIXVersion: '0.1100'
+  MSIXVersion: '0.1200'
   solution: '**/DevHomeAzureExtension.sln'
   appxPackageDir: 'AppxPackages'
   testOutputArtifactDir: 'TestResults'

--- a/build/scripts/Build.ps1
+++ b/build/scripts/Build.ps1
@@ -62,63 +62,22 @@ $ErrorActionPreference = "Stop"
 Try {
   if (($BuildStep -ieq "all") -Or ($BuildStep -ieq "msix")) {
     $buildRing = "Dev"
-    $newPackageName = $null
-    $newPackageDisplayName = $null
-    $newAppDisplayNameResource = $null
-    $newWidgetProviderDisplayName = $null
+    $appxmanifestPath = (Join-Path $env:Build_RootDirectory "src\AzureExtensionServer\Package-Dev.appxmanifest")
 
     if ($AzureBuildingBranch -ieq "release") {
       $buildRing = "Stable"
-      $newPackageName = "Microsoft.Windows.DevHomeAzureExtension"
-      $newPackageDisplayName = "Dev Home Azure Extension (Preview)"
-      $newAppDisplayNameResource = "ms-resource:AppDisplayNameStable"
-      $newWidgetProviderDisplayName = "ms-resource:WidgetProviderDisplayNameStable"
+      $appxmanifestPath = (Join-Path $env:Build_RootDirectory "src\AzureExtensionServer\Package.appxmanifest")
     } elseif ($AzureBuildingBranch -ieq "staging") {
       $buildRing = "Canary"
-      $newPackageName = "Microsoft.Windows.DevHomeAzureExtension.Canary"
-      $newPackageDisplayName = "Dev Home Azure Extension (Canary)"
-      $newAppDisplayNameResource = "ms-resource:AppDisplayNameCanary"
-      $newWidgetProviderDisplayName = "ms-resource:WidgetProviderDisplayNameCanary"
+      $appxmanifestPath = (Join-Path $env:Build_RootDirectory "src\AzureExtensionServer\Package-Can.appxmanifest")
     }
 
     [Reflection.Assembly]::LoadWithPartialName("System.Xml.Linq")
     $xIdentity = [System.Xml.Linq.XName]::Get("{http://schemas.microsoft.com/appx/manifest/foundation/windows10}Identity");
-    $xProperties = [System.Xml.Linq.XName]::Get("{http://schemas.microsoft.com/appx/manifest/foundation/windows10}Properties");
-    $xDisplayName = [System.Xml.Linq.XName]::Get("{http://schemas.microsoft.com/appx/manifest/foundation/windows10}DisplayName");
-    $xApplications = [System.Xml.Linq.XName]::Get("{http://schemas.microsoft.com/appx/manifest/foundation/windows10}Applications");
-    $xApplication = [System.Xml.Linq.XName]::Get("{http://schemas.microsoft.com/appx/manifest/foundation/windows10}Application");
-    $uapVisualElements = [System.Xml.Linq.XName]::Get("{http://schemas.microsoft.com/appx/manifest/uap/windows10}VisualElements");
-    $xExtensions = [System.Xml.Linq.XName]::Get("{http://schemas.microsoft.com/appx/manifest/foundation/windows10}Extensions");
-    $uapExtension = [System.Xml.Linq.XName]::Get("{http://schemas.microsoft.com/appx/manifest/uap/windows10/3}Extension");
-    $uapAppExtension = [System.Xml.Linq.XName]::Get("{http://schemas.microsoft.com/appx/manifest/uap/windows10/3}AppExtension");
 
     # Update the appxmanifest
-    $appxmanifestPath = (Join-Path $env:Build_RootDirectory "src\AzureExtensionServer\Package.appxmanifest")
     $appxmanifest = [System.Xml.Linq.XDocument]::Load($appxmanifestPath)
     $appxmanifest.Root.Element($xIdentity).Attribute("Version").Value = $env:msix_version
-    if (-not ([string]::IsNullOrEmpty($newPackageName))) {
-      $appxmanifest.Root.Element($xIdentity).Attribute("Name").Value = $newPackageName
-    } 
-    if (-not ([string]::IsNullOrEmpty($newPackageDisplayName))) {
-      $appxmanifest.Root.Element($xProperties).Element($xDisplayName).Value = $newPackageDisplayName
-    }
-    if (-not ([string]::IsNullOrEmpty($newAppDisplayNameResource))) {
-      $appxmanifest.Root.Element($xApplications).Element($xApplication).Element($uapVisualElements).Attribute("DisplayName").Value = $newAppDisplayNameResource
-      $extensions = $appxmanifest.Root.Element($xApplications).Element($xApplication).Element($xExtensions).Elements($uapExtension)
-      foreach ($extension in $extensions) {
-        if ($extension.Attribute("Category").Value -eq "windows.appExtension") {
-          $appExtension = $extension.Element($uapAppExtension)
-          switch ($appExtension.Attribute("Name").Value) {
-            "com.microsoft.devhome" {
-              $appExtension.Attribute("DisplayName").Value = $newAppDisplayNameResource
-            }
-            "com.microsoft.windows.widgets" {
-              $appExtension.Attribute("DisplayName").Value = $newWidgetProviderDisplayName
-            }
-          }
-        }
-      }
-    }
     $appxmanifest.Save($appxmanifestPath)
 
     foreach ($platform in $env:Build_Platform.Split(",")) {
@@ -148,23 +107,6 @@ Try {
     # Reset the appxmanifest to prevent unnecessary code changes
     $appxmanifest = [System.Xml.Linq.XDocument]::Load($appxmanifestPath)
     $appxmanifest.Root.Element($xIdentity).Attribute("Version").Value = "0.0.0.0"
-    $appxmanifest.Root.Element($xIdentity).Attribute("Name").Value = "Microsoft.Windows.DevHomeAzureExtension.Dev"
-    $appxmanifest.Root.Element($xProperties).Element($xDisplayName).Value = "Dev Home Azure Extension (Dev)"
-    $appxmanifest.Root.Element($xApplications).Element($xApplication).Element($uapVisualElements).Attribute("DisplayName").Value = "ms-resource:AppDisplayNameDev"
-    $extensions = $appxmanifest.Root.Element($xApplications).Element($xApplication).Element($xExtensions).Elements($uapExtension)
-    foreach ($extension in $extensions) {
-      if ($extension.Attribute("Category").Value -eq "windows.appExtension") {
-        $appExtension = $extension.Element($uapAppExtension)
-        switch ($appExtension.Attribute("Name").Value) {
-          "com.microsoft.devhome" {
-            $appExtension.Attribute("DisplayName").Value = "ms-resource:AppDisplayNameDev"
-          }
-          "com.microsoft.windows.widgets" {
-            $appExtension.Attribute("DisplayName").Value = "ms-resource:WidgetProviderDisplayNameDev"
-          }
-        }
-      }
-    }
     $appxmanifest.Save($appxmanifestPath)
   }
 

--- a/build/scripts/CreateBuildInfo.ps1
+++ b/build/scripts/CreateBuildInfo.ps1
@@ -5,7 +5,7 @@ Param(
 )
 
 $Major = "0"
-$Minor = "11"
+$Minor = "12"
 $Patch = "99" # default to 99 for local builds
 
 $versionSplit = $Version.Split(".");

--- a/src/AzureExtension/AzureExtension.cs
+++ b/src/AzureExtension/AzureExtension.cs
@@ -14,7 +14,13 @@ using Serilog;
 namespace DevHomeAzureExtension;
 
 [ComVisible(true)]
+#if CANARY_BUILD
+[Guid("0F3605DE-92CF-4FE0-9BCD-A3519EA67D1B")]
+#elif STABLE_BUILD
 [Guid("182AF84F-D5E1-469C-9742-536EFEA94630")]
+#else
+[Guid("28A2AB40-26EA-48BF-A8BC-49FEC9B7C18C")]
+#endif
 [ComDefaultInterface(typeof(IExtension))]
 public sealed class AzureExtension : IExtension
 {

--- a/src/AzureExtension/Widgets/WidgetProvider.cs
+++ b/src/AzureExtension/Widgets/WidgetProvider.cs
@@ -9,7 +9,13 @@ namespace DevHomeAzureExtension.Widgets;
 
 [ComVisible(true)]
 [ClassInterface(ClassInterfaceType.None)]
+#if CANARY_BUILD
+[Guid("5C844D91-B497-4D59-AE73-CDC895B1EB2F")]
+#elif STABLE_BUILD
 [Guid("B91B13BB-B3B4-4F2E-9EF9-554757F33E1C")]
+#else
+[Guid("1A7EFA8B-2CFA-4130-93B0-92BC0230C84E")]
+#endif
 public sealed class WidgetProvider : IWidgetProvider, IWidgetProvider2
 {
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(WidgetProvider));

--- a/src/AzureExtensionServer/AzureExtensionServer.csproj
+++ b/src/AzureExtensionServer/AzureExtensionServer.csproj
@@ -37,6 +37,24 @@
     <Folder Include="Assets\" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(BuildRing)' == 'Dev'">
+    <AppxManifest Include="Package-Dev.appxmanifest">
+      <SubType>Designer</SubType>
+    </AppxManifest>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BuildRing)' == 'Canary'">
+    <AppxManifest Include="Package-Can.appxmanifest">
+      <SubType>Designer</SubType>
+    </AppxManifest>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BuildRing)' == 'Stable'">
+    <AppxManifest Include="Package.appxmanifest">
+      <SubType>Designer</SubType>
+    </AppxManifest>
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />

--- a/src/AzureExtensionServer/Package-Can.appxmanifest
+++ b/src/AzureExtensionServer/Package-Can.appxmanifest
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/templatestudio" xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" IgnorableNamespaces="uap uap3 rescap genTemplate">
-  <Identity Name="Microsoft.Windows.DevHomeAzureExtension" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
+  <Identity Name="Microsoft.Windows.DevHomeAzureExtension.Can" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
   <Properties>
-    <DisplayName>Dev Home Azure Extension</DisplayName>
+    <DisplayName>Dev Home Azure Extension (Can)</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
@@ -14,7 +14,7 @@
   </Resources>
   <Applications>
     <Application Id="App" Executable="DevHomeAzureExtension.exe" EntryPoint="$targetentrypoint$">
-      <uap:VisualElements DisplayName="ms-resource:AppDisplayNameStable" Description="ms-resource:AppDescription" AppListEntry="none" BackgroundColor="transparent" Square150x150Logo="Assets\MedTile.png" Square44x44Logo="Assets\AppList.png">
+      <uap:VisualElements DisplayName="ms-resource:AppDisplayNameCanary" Description="ms-resource:AppDescription" AppListEntry="none" BackgroundColor="transparent" Square150x150Logo="Assets\MedTile.png" Square44x44Logo="Assets\AppList.png">
         <uap:DefaultTile Wide310x150Logo="Assets\WideTile.png" />
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
@@ -22,23 +22,23 @@
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:ExeServer Executable="DevHomeAzureExtension.exe" Arguments="-RegisterProcessAsComServer" DisplayName="Azure Provider Widget">
-              <com:Class Id="B91B13BB-B3B4-4F2E-9EF9-554757F33E1C" DisplayName="Azure Provider Widget" />
+              <com:Class Id="5C844D91-B497-4D59-AE73-CDC895B1EB2F" DisplayName="Azure Provider Widget" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:ExeServer Executable="DevHomeAzureExtension.exe" Arguments="-RegisterProcessAsComServer" DisplayName="Azure Extension Provider">
-              <com:Class Id="182AF84F-D5E1-469C-9742-536EFEA94630" DisplayName="Azure Extension Provider" />
+              <com:Class Id="0F3605DE-92CF-4FE0-9BCD-A3519EA67D1B" DisplayName="Azure Extension Provider" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameStable" Description="ms-resource:AppDescription">
+          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameCanary" Description="ms-resource:AppDescription">
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>
-                  <CreateInstance ClassId="182AF84F-D5E1-469C-9742-536EFEA94630" />
+                  <CreateInstance ClassId="0F3605DE-92CF-4FE0-9BCD-A3519EA67D1B" />
                 </Activation>
                 <SupportedInterfaces>
                   <DeveloperId />
@@ -62,7 +62,7 @@
           </com:ComServer>
         </com:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.windows.widgets" DisplayName="ms-resource:WidgetProviderDisplayNameStable" Id="01" PublicFolder="Public">
+          <uap3:AppExtension Name="com.microsoft.windows.widgets" DisplayName="ms-resource:WidgetProviderDisplayNameCanary" Id="01" PublicFolder="Public">
             <uap3:Properties>
               <WidgetProvider>
                 <ProviderIcons>
@@ -70,7 +70,7 @@
                 </ProviderIcons>
                 <Activation>
                   <!-- Apps exports COM interface which implements IWidgetProvider -->
-                  <CreateInstance ClassId="B91B13BB-B3B4-4F2E-9EF9-554757F33E1C" />
+                  <CreateInstance ClassId="5C844D91-B497-4D59-AE73-CDC895B1EB2F" />
                 </Activation>
                 <Definitions>
                   <Definition Id="Azure_QueryList" DisplayName="Query Result" Description="Azure Query List Widget" IsCustomizable="true">

--- a/src/AzureExtensionServer/Package-Dev.appxmanifest
+++ b/src/AzureExtensionServer/Package-Dev.appxmanifest
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/templatestudio" xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" IgnorableNamespaces="uap uap3 rescap genTemplate">
-  <Identity Name="Microsoft.Windows.DevHomeAzureExtension" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
+  <Identity Name="Microsoft.Windows.DevHomeAzureExtension.Dev" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
   <Properties>
-    <DisplayName>Dev Home Azure Extension</DisplayName>
+    <DisplayName>Dev Home Azure Extension (Dev)</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
@@ -14,7 +14,7 @@
   </Resources>
   <Applications>
     <Application Id="App" Executable="DevHomeAzureExtension.exe" EntryPoint="$targetentrypoint$">
-      <uap:VisualElements DisplayName="ms-resource:AppDisplayNameStable" Description="ms-resource:AppDescription" AppListEntry="none" BackgroundColor="transparent" Square150x150Logo="Assets\MedTile.png" Square44x44Logo="Assets\AppList.png">
+      <uap:VisualElements DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescription" AppListEntry="none" BackgroundColor="transparent" Square150x150Logo="Assets\MedTile.png" Square44x44Logo="Assets\AppList.png">
         <uap:DefaultTile Wide310x150Logo="Assets\WideTile.png" />
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
@@ -22,23 +22,23 @@
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:ExeServer Executable="DevHomeAzureExtension.exe" Arguments="-RegisterProcessAsComServer" DisplayName="Azure Provider Widget">
-              <com:Class Id="B91B13BB-B3B4-4F2E-9EF9-554757F33E1C" DisplayName="Azure Provider Widget" />
+              <com:Class Id="1A7EFA8B-2CFA-4130-93B0-92BC0230C84E" DisplayName="Azure Provider Widget" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:ExeServer Executable="DevHomeAzureExtension.exe" Arguments="-RegisterProcessAsComServer" DisplayName="Azure Extension Provider">
-              <com:Class Id="182AF84F-D5E1-469C-9742-536EFEA94630" DisplayName="Azure Extension Provider" />
+              <com:Class Id="28A2AB40-26EA-48BF-A8BC-49FEC9B7C18C" DisplayName="Azure Extension Provider" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameStable" Description="ms-resource:AppDescription">
+          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescription">
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>
-                  <CreateInstance ClassId="182AF84F-D5E1-469C-9742-536EFEA94630" />
+                  <CreateInstance ClassId="28A2AB40-26EA-48BF-A8BC-49FEC9B7C18C" />
                 </Activation>
                 <SupportedInterfaces>
                   <DeveloperId />
@@ -62,7 +62,7 @@
           </com:ComServer>
         </com:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.windows.widgets" DisplayName="ms-resource:WidgetProviderDisplayNameStable" Id="01" PublicFolder="Public">
+          <uap3:AppExtension Name="com.microsoft.windows.widgets" DisplayName="ms-resource:WidgetProviderDisplayNameDev" Id="01" PublicFolder="Public">
             <uap3:Properties>
               <WidgetProvider>
                 <ProviderIcons>
@@ -70,7 +70,7 @@
                 </ProviderIcons>
                 <Activation>
                   <!-- Apps exports COM interface which implements IWidgetProvider -->
-                  <CreateInstance ClassId="B91B13BB-B3B4-4F2E-9EF9-554757F33E1C" />
+                  <CreateInstance ClassId="1A7EFA8B-2CFA-4130-93B0-92BC0230C84E" />
                 </Activation>
                 <Definitions>
                   <Definition Id="Azure_QueryList" DisplayName="Query Result" Description="Azure Query List Widget" IsCustomizable="true">


### PR DESCRIPTION
## Summary of the pull request
Stable/Canary/Dev builds all use the same ClassIds in package.appxmanifest.  This causes issues when multiple versions are installed at the same time, notably not being able to determine which version will actually get activated.  This change clones package.appxmanifest into three different versions and changes the ClassIds for Canary/Dev versions (Stable remains the same).

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
