### PR TITLE
Toast notifications for Azure pull requests (Rejected and Approved)

### DIFF
--- a/src/AzureExtension/DataManager/AzureDataManager.cs
+++ b/src/AzureExtension/DataManager/AzureDataManager.cs
@@ -178,7 +178,7 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
             LoginId = developerLogin,
             DeveloperId = DeveloperIdProvider.GetInstance().GetDeveloperIdFromAccountIdentifier(developerLogin),
             RequestOptions = options ?? RequestOptions.RequestOptionsDefault(),
-            OperationName = "UpdateDataForQueryAsync",
+            OperationName = nameof(UpdateDataForQueriesAsync),
             Requestor = requestor ?? Guid.NewGuid(),
         };
 
@@ -218,7 +218,7 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
             DeveloperId = DeveloperIdProvider.GetInstance().GetDeveloperIdFromAccountIdentifier(developerLogin),
             PullRequestView = view,
             RequestOptions = options ?? RequestOptions.RequestOptionsDefault(),
-            OperationName = "UpdateDataForPullRequestsAsync",
+            OperationName = nameof(UpdateDataForPullRequestsAsync),
             Requestor = requestor ?? Guid.NewGuid(),
         };
 
@@ -621,7 +621,7 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
                 repository,
                 parameters.DeveloperId.LoginId,
                 parameters.PullRequestView,
-                parameters.OperationName == "UpdateDataForDeveloperPullRequestsAsync");
+                parameters.OperationName == nameof(UpdateDataForDeveloperPullRequestsAsync));
         } // Foreach AzureUri
 
         return;
@@ -633,7 +633,7 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
         var parameters = new DataStoreOperationParameters
         {
             RequestOptions = options ?? RequestOptions.RequestOptionsDefault(),
-            OperationName = "UpdatePullRequestsForLoggedInDeveloperIdsAsync",
+            OperationName = nameof(UpdatePullRequestsForLoggedInDeveloperIdsAsync),
             PullRequestView = PullRequestView.Mine,
             Requestor = requestor ?? Guid.NewGuid(),
         };
@@ -681,7 +681,7 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
                     Uris = uris,
                     DeveloperId = repositoryRef.Developer.DeveloperId,
                     RequestOptions = parameters.RequestOptions,
-                    OperationName = "UpdateDataForDeveloperPullRequestsAsync",
+                    OperationName = nameof(UpdateDataForDeveloperPullRequestsAsync),
                     PullRequestView = PullRequestView.Mine,
                     Requestor = parameters.Requestor,
                 };

--- a/src/AzureExtension/DataManager/AzureDataManager.cs
+++ b/src/AzureExtension/DataManager/AzureDataManager.cs
@@ -676,8 +676,6 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
             foreach (var repositoryRef in repositoryReferences)
             {
                 var uri = new AzureUri(repositoryRef.Repository.CloneUrl);
-                var developerId = repositoryRef.Developer.DeveloperLoginId;
-
                 var uris = new List<AzureUri>
                 {
                     new(repositoryRef.Repository.CloneUrl),

--- a/src/AzureExtension/DataManager/AzureDataManager.cs
+++ b/src/AzureExtension/DataManager/AzureDataManager.cs
@@ -726,7 +726,8 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
 
             // ArtifactId is null in the pull request object and it is not the correct object. The ArtifactId for the
             // Policy Evaluations API is this:
-            // vstfs:///CodeReview/CodeReviewId/{projectId}/{pullRequestId}
+            //     vstfs:///CodeReview/CodeReviewId/{projectId}/{pullRequestId}
+            // Documentation: https://learn.microsoft.com/en-us/dotnet/api/microsoft.teamfoundation.policy.webapi.policyevaluationrecord.artifactid
             var artifactId = $"vstfs:///CodeReview/CodeReviewId/{project.InternalId}/{pullRequest.PullRequestId}";
 
             // Url in the GitPullRequest object is a REST Api Url, and the links lack an html Url, so we must build it.
@@ -877,7 +878,7 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
             {
                 // If the previous status was not failed, or the failure was for a different
                 // reason, then create a new notification.
-                if (!prevStatus.Rejected || curStatus.PolicyStatusReason != prevStatus.PolicyStatusReason)
+                if (!prevStatus.Rejected || (curStatus.PolicyStatusReason != prevStatus.PolicyStatusReason))
                 {
                     return true;
                 }

--- a/src/AzureExtension/DataManager/AzureDataManager.cs
+++ b/src/AzureExtension/DataManager/AzureDataManager.cs
@@ -293,11 +293,6 @@ public partial class AzureDataManager : IAzureDataManager, IDisposable
         return GetPullRequests(repositoryUri.Organization, repositoryUri.Project, repositoryUri.Repository, developerId, view);
     }
 
-    public PullRequests? GetPullRequestsForLoggedInDeveloperIds()
-    {
-        return null;
-    }
-
     private async Task UpdateDataForQueriesAsync(DataStoreOperationParameters parameters)
     {
         _log.Debug($"Inside UpdateDataForQueriesAsync with Parameters: {parameters}");

--- a/src/AzureExtension/DataManager/AzureDataManagerCache.cs
+++ b/src/AzureExtension/DataManager/AzureDataManagerCache.cs
@@ -150,7 +150,7 @@ public partial class AzureDataManager
     private void UpdateOrganization(Account account, DeveloperId.DeveloperId developerId, VssConnection connection, CancellationToken cancellationToken)
     {
         // Update account identity information:
-        var identity = Identity.GetOrCreateIdentity(DataStore, connection.AuthorizedIdentity, connection, true);
+        var identity = Identity.GetOrCreateIdentity(DataStore, connection.AuthorizedIdentity, connection, developerId.LoginId);
 
         _log.Verbose($"Updating organization: {account.AccountName}");
         var organization = Organization.GetOrCreate(DataStore, account.AccountUri);

--- a/src/AzureExtension/DataManager/AzureDataManagerUpdate.cs
+++ b/src/AzureExtension/DataManager/AzureDataManagerUpdate.cs
@@ -37,12 +37,13 @@ public partial class AzureDataManager
 
     public static async Task UpdateDeveloperPullRequests()
     {
-        Log.Debug($"Executing UpdateDeveloperPullRequests");
+        var log = Log.ForContext("SourceContext", $"UpdateDeveloperPullRequests");
+        log.Debug($"Executing UpdateDeveloperPullRequests");
 
         var cacheManager = CacheManager.GetInstance();
         if (cacheManager.UpdateInProgress)
         {
-            Log.Information("Cache is being updated, skipping Developer Pull Request Update");
+            log.Information("Cache is being updated, skipping Developer Pull Request Update");
             return;
         }
 

--- a/src/AzureExtension/DataManager/AzureDataManagerUpdate.cs
+++ b/src/AzureExtension/DataManager/AzureDataManagerUpdate.cs
@@ -18,7 +18,7 @@ public partial class AzureDataManager
     {
         // Only update per the update interval.
         // This is intended to be dynamic in the future.
-        if (DateTime.Now - _lastUpdateTime < _updateInterval)
+        if (DateTime.UtcNow - _lastUpdateTime < _updateInterval)
         {
             return;
         }
@@ -32,7 +32,7 @@ public partial class AzureDataManager
             Log.Error(ex, "Update failed unexpectedly.");
         }
 
-        _lastUpdateTime = DateTime.Now;
+        _lastUpdateTime = DateTime.UtcNow;
     }
 
     public static async Task UpdateDeveloperPullRequests()

--- a/src/AzureExtension/DataManager/AzureDataManagerUpdate.cs
+++ b/src/AzureExtension/DataManager/AzureDataManagerUpdate.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using DevHomeAzureExtension.DataManager;
+using DevHomeAzureExtension.DataModel;
 using Microsoft.TeamFoundation.Policy.WebApi;
 using Serilog;
 
@@ -50,22 +51,14 @@ public partial class AzureDataManager
         await dataManager.UpdatePullRequestsForLoggedInDeveloperIdsAsync(null, identifier);
 
         // Show any new notifications that were created from the pull request update.
-        /*
         var notifications = dataManager.GetNotifications();
         foreach (var notification in notifications)
         {
             // Show notifications for failed checkruns for Developer users.
-            if (notification.Type == NotificationType.CheckRunFailed && notification.User.IsDeveloper)
-            {
-                notification.ShowToast();
-            }
-
-            // Show notifications for new reviews.
-            if (notification.Type == NotificationType.NewReview)
+            if (notification.Type == NotificationType.PullRequestRejected || notification.Type == NotificationType.PullRequestApproved)
             {
                 notification.ShowToast();
             }
         }
-        */
     }
 }

--- a/src/AzureExtension/DataManager/DataManagerUpdateEventArgs.cs
+++ b/src/AzureExtension/DataManager/DataManagerUpdateEventArgs.cs
@@ -12,6 +12,7 @@ public enum DataManagerUpdateKind
     Error,
     Cache,
     Cancel,
+    Developer,
 }
 
 public class DataManagerUpdateEventArgs : EventArgs

--- a/src/AzureExtension/DataManager/IAzureDataManager.cs
+++ b/src/AzureExtension/DataManager/IAzureDataManager.cs
@@ -26,15 +26,21 @@ public interface IAzureDataManager : IDisposable
 
     Task UpdateDataForPullRequestsAsync(AzureUri repositoryUri, string developerLogin, PullRequestView view, RequestOptions? options = null, Guid? requestor = null);
 
+    Task UpdatePullRequestsForLoggedInDeveloperIdsAsync(RequestOptions? options = null, Guid? requestor = null);
+
     Query? GetQuery(string queryId, string developerId);
 
     Query? GetQuery(AzureUri queryUri, string developerId);
 
     IEnumerable<Repository> GetRepositories();
 
+    IEnumerable<Repository> GetDeveloperRepositories();
+
     // Repository name may not be unique across projects, and projects may not be unique across
     // organizations, so we need all three to identify the repository.
     PullRequests? GetPullRequests(string organization, string project, string repositoryName, string developerId, PullRequestView view);
 
     PullRequests? GetPullRequests(AzureUri repositoryUri, string developerId, PullRequestView view);
+
+    PullRequests? GetPullRequestsForLoggedInDeveloperIds();
 }

--- a/src/AzureExtension/DataManager/IAzureDataManager.cs
+++ b/src/AzureExtension/DataManager/IAzureDataManager.cs
@@ -32,6 +32,10 @@ public interface IAzureDataManager : IDisposable
 
     Query? GetQuery(AzureUri queryUri, string developerId);
 
+    Identity GetIdentity(long id);
+
+    WorkItemType GetWorkItemType(long id);
+
     IEnumerable<Repository> GetRepositories();
 
     IEnumerable<Repository> GetDeveloperRepositories();

--- a/src/AzureExtension/DataManager/IAzureDataManager.cs
+++ b/src/AzureExtension/DataManager/IAzureDataManager.cs
@@ -36,6 +36,8 @@ public interface IAzureDataManager : IDisposable
 
     WorkItemType GetWorkItemType(long id);
 
+    IEnumerable<Notification> GetNotifications(DateTime? since = null, bool includeToasted = false);
+
     IEnumerable<Repository> GetRepositories();
 
     IEnumerable<Repository> GetDeveloperRepositories();

--- a/src/AzureExtension/DataManager/IAzureDataManager.cs
+++ b/src/AzureExtension/DataManager/IAzureDataManager.cs
@@ -47,6 +47,4 @@ public interface IAzureDataManager : IDisposable
     PullRequests? GetPullRequests(string organization, string project, string repositoryName, string developerId, PullRequestView view);
 
     PullRequests? GetPullRequests(AzureUri repositoryUri, string developerId, PullRequestView view);
-
-    PullRequests? GetPullRequestsForLoggedInDeveloperIds();
 }

--- a/src/AzureExtension/DataModel/AzureDataStoreSchema.cs
+++ b/src/AzureExtension/DataModel/AzureDataStoreSchema.cs
@@ -14,7 +14,7 @@ public class AzureDataStoreSchema : IDataStoreSchema
     }
 
     // Update this anytime incompatible changes happen with a released version.
-    private const long SchemaVersionValue = 0x0007;
+    private const long SchemaVersionValue = 0x0008;
 
     private const string Metadata =
     @"CREATE TABLE Metadata (" +
@@ -154,6 +154,39 @@ public class AzureDataStoreSchema : IDataStoreSchema
     // the developer login, and the view.
     "CREATE UNIQUE INDEX IDX_PullRequests_ProjectIdRepositoryIdDeveloperLoginViewId ON PullRequests (ProjectId, RepositoryId, DeveloperLogin, ViewId);";
 
+    // PullRequsetPolicyStatus is a snapshot of a developer's Pull Requests.
+    private const string PullRequestPolicyStatus =
+    @"CREATE TABLE PullRequestPolicyStatus (" +
+        "Id INTEGER PRIMARY KEY NOT NULL," +
+        "ArtifactId TEXT NULL COLLATE NOCASE," +
+        "ProjectId INTEGER NOT NULL," +
+        "RepositoryId INTEGER NOT NULL," +
+        "PullRequestId INTEGER NOT NULL," +
+        "Title TEXT NULL COLLATE NOCASE," +
+        "PolicyStatusId INTEGER NOT NULL," +
+        "PolicyStatusReason TEXT NULL COLLATE NOCASE," +
+        "PullRequestStatusId INTEGER NOT NULL," +
+        "TargetBranchName TEXT NULL COLLATE NOCASE," +
+        "HtmlUrl TEXT NULL COLLATE NOCASE," +
+        "TimeUpdated INTEGER NOT NULL," +
+        "TimeCreated INTEGER NOT NULL" +
+    ");";
+
+    private const string Notification =
+    @"CREATE TABLE Notification (" +
+        "Id INTEGER PRIMARY KEY NOT NULL," +
+        "TypeId INTEGER NOT NULL," +
+        "ProjectId INTEGER NOT NULL," +
+        "RepositoryId INTEGER NOT NULL," +
+        "Title TEXT NOT NULL COLLATE NOCASE," +
+        "Description TEXT NOT NULL COLLATE NOCASE," +
+        "Identifier TEXT NULL COLLATE NOCASE," +
+        "Result TEXT NULL COLLATE NOCASE," +
+        "HtmlUrl TEXT NULL COLLATE NOCASE," +
+        "ToastState INTEGER NOT NULL," +
+        "TimeCreated INTEGER NOT NULL" +
+    ");";
+
     // All Sqls together.
     private static readonly List<string> _schemaSqlsValue =
     [
@@ -167,5 +200,7 @@ public class AzureDataStoreSchema : IDataStoreSchema
         Query,
         WorkItemType,
         PullRequests,
+        PullRequestPolicyStatus,
+        Notification,
     ];
 }

--- a/src/AzureExtension/DataModel/AzureDataStoreSchema.cs
+++ b/src/AzureExtension/DataModel/AzureDataStoreSchema.cs
@@ -14,7 +14,7 @@ public class AzureDataStoreSchema : IDataStoreSchema
     }
 
     // Update this anytime incompatible changes happen with a released version.
-    private const long SchemaVersionValue = 0x0008;
+    private const long SchemaVersionValue = 0x0007;
 
     private const string Metadata =
     @"CREATE TABLE Metadata (" +

--- a/src/AzureExtension/DataModel/AzureDataStoreSchema.cs
+++ b/src/AzureExtension/DataModel/AzureDataStoreSchema.cs
@@ -30,7 +30,7 @@ public class AzureDataStoreSchema : IDataStoreSchema
         "Name TEXT NOT NULL COLLATE NOCASE," +
         "InternalId TEXT NOT NULL," +
         "Avatar TEXT NOT NULL COLLATE NOCASE," +
-        "DeveloperLoginId TEXT NOT NULL," +
+        "DeveloperLoginId TEXT," +
         "TimeUpdated INTEGER NOT NULL" +
     ");" +
 

--- a/src/AzureExtension/DataModel/AzureDataStoreSchema.cs
+++ b/src/AzureExtension/DataModel/AzureDataStoreSchema.cs
@@ -14,7 +14,7 @@ public class AzureDataStoreSchema : IDataStoreSchema
     }
 
     // Update this anytime incompatible changes happen with a released version.
-    private const long SchemaVersionValue = 0x0006;
+    private const long SchemaVersionValue = 0x0007;
 
     private const string Metadata =
     @"CREATE TABLE Metadata (" +
@@ -30,7 +30,7 @@ public class AzureDataStoreSchema : IDataStoreSchema
         "Name TEXT NOT NULL COLLATE NOCASE," +
         "InternalId TEXT NOT NULL," +
         "Avatar TEXT NOT NULL COLLATE NOCASE," +
-        "IsDeveloper INTEGER NOT NULL," +
+        "DeveloperLoginId TEXT NOT NULL," +
         "TimeUpdated INTEGER NOT NULL" +
     ");" +
 
@@ -89,6 +89,10 @@ public class AzureDataStoreSchema : IDataStoreSchema
         "TimeUpdated INTEGER NOT NULL" +
     ");" +
 
+    // While Name and ProjectId should be unique, it is possible renaming occurs and
+    // we might have a collision if we have cached a repository prior to rename and
+    // then encounter a different repository with that name. Therefore we will not
+    // create a unique index on ProjectId and Name.
     // Repository InternalId is a Guid, so by definition is unique.
     "CREATE UNIQUE INDEX IDX_Repository_InternalId ON Repository (InternalId);";
 
@@ -138,7 +142,7 @@ public class AzureDataStoreSchema : IDataStoreSchema
     private const string PullRequests =
     @"CREATE TABLE PullRequests (" +
         "Id INTEGER PRIMARY KEY NOT NULL," +
-        "RepositoryName TEXT NOT NULL COLLATE NOCASE," +
+        "RepositoryId INTEGER NOT NULL," +
         "DeveloperLogin TEXT NOT NULL COLLATE NOCASE," +
         "Results TEXT NOT NULL," +
         "ProjectId INTEGER NOT NULL," +
@@ -148,7 +152,7 @@ public class AzureDataStoreSchema : IDataStoreSchema
 
     // Developer Pull requests are unique on Org / Project / Repository and
     // the developer login, and the view.
-    "CREATE UNIQUE INDEX IDX_PullRequests_ProjectIdRepositoryNameDeveloperLoginViewId ON PullRequests (ProjectId, RepositoryName, DeveloperLogin, ViewId);";
+    "CREATE UNIQUE INDEX IDX_PullRequests_ProjectIdRepositoryIdDeveloperLoginViewId ON PullRequests (ProjectId, RepositoryId, DeveloperLogin, ViewId);";
 
     // All Sqls together.
     private static readonly List<string> _schemaSqlsValue =

--- a/src/AzureExtension/DataModel/DataObjects/Identity.cs
+++ b/src/AzureExtension/DataModel/DataObjects/Identity.cs
@@ -46,7 +46,7 @@ public class Identity
 
     // The DeveloperLoginId associated with this identity, if one exists.
     // Empty means there is no associated LoggedInDeveloperId.
-    public string DeveloperLoginId { get; set; } = string.Empty;
+    public string? DeveloperLoginId { get; set; }
 
     [JsonIgnore]
     public long TimeUpdated { get; set; } = DataStore.NoForeignKey;
@@ -73,7 +73,7 @@ public class Identity
             }
 
             var devIdProvider = DeveloperIdProvider.GetInstance();
-            return devIdProvider.GetDeveloperIdFromAccountIdentifier(DeveloperLoginId);
+            return devIdProvider.GetDeveloperIdFromAccountIdentifier(DeveloperLoginId!);
         }
     }
 
@@ -163,7 +163,7 @@ public class Identity
         };
     }
 
-    public static Identity AddOrUpdateIdentity(DataStore dataStore, Identity identity, string developerLoginId = "")
+    public static Identity AddOrUpdateIdentity(DataStore dataStore, Identity identity, string? developerLoginId = null)
     {
         // Check for existing Identity data.
         var existingIdentity = GetByInternalId(dataStore, identity.InternalId);
@@ -171,7 +171,6 @@ public class Identity
         {
             identity.Id = existingIdentity.Id;
 
-            // If this is a developer, set to developer, but do not set it.
             // We presume not a developer unless it is explicitly set.
             if (!string.IsNullOrEmpty(developerLoginId))
             {

--- a/src/AzureExtension/DataModel/DataObjects/Identity.cs
+++ b/src/AzureExtension/DataModel/DataObjects/Identity.cs
@@ -45,7 +45,6 @@ public class Identity
     public string Avatar { get; set; } = string.Empty;
 
     // The DeveloperLoginId associated with this identity, if one exists.
-    // Empty means there is no associated LoggedInDeveloperId.
     public string? DeveloperLoginId { get; set; }
 
     [JsonIgnore]

--- a/src/AzureExtension/DataModel/DataObjects/Notification.cs
+++ b/src/AzureExtension/DataModel/DataObjects/Notification.cs
@@ -1,0 +1,262 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Dapper;
+using Dapper.Contrib.Extensions;
+using DevHomeAzureExtension.Helpers;
+using Microsoft.TeamFoundation.SourceControl.WebApi;
+using Microsoft.Windows.ApplicationModel.Resources;
+using Microsoft.Windows.AppNotifications;
+using Microsoft.Windows.AppNotifications.Builder;
+using Serilog;
+
+namespace DevHomeAzureExtension.DataModel;
+
+/// <summary>
+/// Represents data for rendering a notification to the user.
+/// </summary>
+/// <remarks>
+/// Notifications are sent to the user as Windows notifications, but may have specific filtering,
+/// such as prioritizing certain repositories, or only showing a notification for a current
+/// developer. The contents of the notifications table is a representation of potential
+/// notifications, it does not necessarily mean the notification will be shown to the user. It is
+/// the set of things we believe may be notification-worthy and ultimately user settings and context
+/// will determine when and if the notification gets shown.
+/// </remarks>
+[Table("Notification")]
+public class Notification
+{
+    private static readonly Lazy<ILogger> _logger = new(() => Serilog.Log.ForContext("SourceContext", $"DataModel/{nameof(Notification)}"));
+
+    private static ILogger Log => _logger.Value;
+
+    [Key]
+    public long Id { get; set; } = DataStore.NoForeignKey;
+
+    public long TypeId { get; set; } = DataStore.NoForeignKey;
+
+    // Key in Project table
+    public long ProjectId { get; set; } = DataStore.NoForeignKey;
+
+    // Key in Repository table
+    public long RepositoryId { get; set; } = DataStore.NoForeignKey;
+
+    public string Title { get; set; } = string.Empty;
+
+    public string Identifier { get; set; } = string.Empty;
+
+    public string Result { get; set; } = string.Empty;
+
+    public string Description { get; set; } = string.Empty;
+
+    public string HtmlUrl { get; set; } = string.Empty;
+
+    public long ToastState { get; set; } = DataStore.NoForeignKey;
+
+    public long TimeCreated { get; set; } = DataStore.NoForeignKey;
+
+    [Write(false)]
+    private DataStore? DataStore { get; set; }
+
+    [Write(false)]
+    [Computed]
+    public DateTime CreatedAt => TimeCreated.ToDateTime();
+
+    [Write(false)]
+    [Computed]
+    public Project Project => Project.Get(DataStore, ProjectId);
+
+    [Write(false)]
+    [Computed]
+    public Repository Repository => Repository.Get(DataStore, RepositoryId);
+
+    [Write(false)]
+    [Computed]
+    public NotificationType Type => (NotificationType)TypeId;
+
+    [Write(false)]
+    [Computed]
+    public bool Toasted
+    {
+        get => ToastState != 0;
+        set
+        {
+            ToastState = value ? 1 : 0;
+            if (DataStore is not null)
+            {
+                try
+                {
+                    DataStore.Connection!.Update(this);
+                }
+                catch (Exception ex)
+                {
+                    // Catch errors so we do not throw for something like this. The local ToastState
+                    // will still be set even if the datastore update fails. This could result in a
+                    // toast later being shown twice, however, so report it as an error.
+                    Log.Error(ex, "Failed setting Notification ToastState for Notification Id = {Id}");
+                }
+            }
+        }
+    }
+
+    public override string ToString() => $"[{Type}][{Project}] {Title}";
+
+    /// <summary>
+    /// Shows a toast formatted based on this notification's NotificationType.
+    /// </summary>
+    /// <returns>True if a toast was shown.</returns>
+    public bool ShowToast()
+    {
+        if (Toasted)
+        {
+            return false;
+        }
+        else if (LocalSettings.ReadSettingAsync<string>("NotificationsEnabled").Result == "false")
+        {
+            Toasted = true;
+            return false;
+        }
+
+        return Type switch
+        {
+            NotificationType.PullRequestRejected => ShowPullRequestRejectedToast(),
+            NotificationType.PullRequestApproved => ShowPullRequestApprovedToast(),
+            _ => false,
+        };
+    }
+
+    private bool ShowPullRequestRejectedToast()
+    {
+        try
+        {
+            Log.Information($"Showing Notification for {this}");
+            var nb = new AppNotificationBuilder();
+            nb.SetDuration(AppNotificationDuration.Long);
+            nb.AddArgument("htmlurl", HtmlUrl);
+            nb.AddText($"❌ {Resources.GetResource("Notifications_Toast_PullRequestRejected/Title", Log)} - {Description}");
+            nb.AddText($"#{Identifier} - {Repository.Name}", new AppNotificationTextProperties().SetMaxLines(1));
+            nb.AddText(Title);
+            nb.AddButton(new AppNotificationButton(Resources.GetResource("Notifications_Toast_Button/Dismiss", Log)).AddArgument("action", "dismiss"));
+            AppNotificationManager.Default.Show(nb.BuildNotification());
+
+            Toasted = true;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, $"Failed creating the Notification for {this}");
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool ShowPullRequestApprovedToast()
+    {
+        try
+        {
+            Log.Information($"Showing Notification for {this}");
+            var nb = new AppNotificationBuilder();
+            nb.SetDuration(AppNotificationDuration.Long);
+            nb.AddArgument("htmlurl", HtmlUrl);
+            nb.AddText($"✅ {Resources.GetResource("Notifications_Toast_PullRequestApproved/Title", Log)}");
+            nb.AddText($"#{Identifier} - {Repository.Name}", new AppNotificationTextProperties().SetMaxLines(1));
+            nb.AddText(Title);
+            nb.AddButton(new AppNotificationButton(Resources.GetResource("Notifications_Toast_Button/Dismiss", Log)).AddArgument("action", "dismiss"));
+            AppNotificationManager.Default.Show(nb.BuildNotification());
+
+            Toasted = true;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, $"Failed creating the Notification for {this}");
+            return false;
+        }
+
+        return true;
+    }
+
+    public static Notification Create(DataStore dataStore, PullRequestPolicyStatus status, NotificationType type)
+    {
+        var pullRequestNotification = new Notification
+        {
+            TypeId = (long)type,
+            ProjectId = status.ProjectId,
+            RepositoryId = status.RepositoryId,
+            Title = status.Title,
+            Description = status.PolicyStatusReason,
+            Identifier = status.PullRequestId.ToStringInvariant(),
+            Result = status.PolicyStatus.ToString(),
+            HtmlUrl = status.HtmlUrl,
+            ToastState = 0,
+            TimeCreated = DateTime.Now.ToDataStoreInteger(),
+        };
+
+        Add(dataStore, pullRequestNotification);
+        SetOlderNotificationsToasted(dataStore, pullRequestNotification);
+        return pullRequestNotification;
+    }
+
+    public static Notification Add(DataStore dataStore, Notification notification)
+    {
+        notification.Id = dataStore.Connection!.Insert(notification);
+        notification.DataStore = dataStore;
+        return notification;
+    }
+
+    public static IEnumerable<Notification> Get(DataStore dataStore, DateTime? since = null, bool includeToasted = false)
+    {
+        since ??= DateTime.MinValue;
+        var sql = @"SELECT * FROM Notification WHERE TimeCreated > @Time AND ToastState <= @ToastedCount ORDER BY TimeCreated DESC";
+        var param = new
+        {
+            // Cast to non-nullable type since we ensure it is not null above.
+            Time = ((DateTime)since).ToDataStoreInteger(),
+            ToastedCount = includeToasted ? 1 : 0,
+        };
+
+        Log.Verbose(DataStore.GetSqlLogMessage(sql, param));
+        var notifications = dataStore.Connection!.Query<Notification>(sql, param, null) ?? [];
+        foreach (var notification in notifications)
+        {
+            notification.DataStore = dataStore;
+        }
+
+        return notifications;
+    }
+
+    public static void SetOlderNotificationsToasted(DataStore dataStore, Notification notification)
+    {
+        // Get all untoasted notifications for the same type, project, repository, and identifier that are older
+        // than the specified notification.
+        var sql = @"SELECT * FROM Notification WHERE TypeId = @TypeId AND RepositoryId = @RepositoryId AND Identifier = @Identifier AND ProjectId = @ProjectId AND TimeCreated < @TimeCreated AND ToastState = 0";
+        var param = new
+        {
+            notification.TypeId,
+            notification.RepositoryId,
+            notification.Identifier,
+            notification.ProjectId,
+            notification.TimeCreated,
+        };
+
+        Log.Verbose(DataStore.GetSqlLogMessage(sql, param));
+        var outDatedNotifications = dataStore.Connection!.Query<Notification>(sql, param, null) ?? [];
+        foreach (var olderNotification in outDatedNotifications)
+        {
+            olderNotification.DataStore = dataStore;
+            olderNotification.Toasted = true;
+            Log.Information($"Found older notification for {olderNotification.Identifier} with result {olderNotification.Result}, marking toasted.");
+        }
+    }
+
+    public static void DeleteBefore(DataStore dataStore, DateTime date)
+    {
+        // Delete notifications older than the date listed.
+        var sql = @"DELETE FROM Notification WHERE TimeCreated < $Time;";
+        var command = dataStore.Connection!.CreateCommand();
+        command.CommandText = sql;
+        command.Parameters.AddWithValue("$Time", date.ToDataStoreInteger());
+        Log.Verbose(DataStore.GetCommandLogMessage(sql, command));
+        var rowsDeleted = command.ExecuteNonQuery();
+        Log.Verbose(DataStore.GetDeletedLogMessage(rowsDeleted));
+    }
+}

--- a/src/AzureExtension/DataModel/DataObjects/PullRequestPolicyStatus.cs
+++ b/src/AzureExtension/DataModel/DataObjects/PullRequestPolicyStatus.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Dapper;
+using Dapper.Contrib.Extensions;
+using DevHomeAzureExtension.Helpers;
+using Microsoft.TeamFoundation.Policy.WebApi;
+using Serilog;
+
+namespace DevHomeAzureExtension.DataModel;
+
+[Table("PullRequestPolicyStatus")]
+public class PullRequestPolicyStatus
+{
+    private static readonly Lazy<ILogger> _logger = new(() => Serilog.Log.ForContext("SourceContext", $"DataModel/{nameof(PullRequests)}"));
+
+    private static readonly ILogger _log = _logger.Value;
+
+    [Key]
+    public long Id { get; set; } = DataStore.NoForeignKey;
+
+    // This should suffice as a unique identifier.
+    public string ArtifactId { get; set; } = string.Empty;
+
+    // Key in Project table
+    public long ProjectId { get; set; } = DataStore.NoForeignKey;
+
+    public long PullRequestId { get; set; } = DataStore.NoForeignKey;
+
+    public long TimeUpdated { get; set; } = DataStore.NoForeignKey;
+
+    public long PolicyStatusId { get; set; } = DataStore.NoForeignKey;
+
+    public override string ToString() => ArtifactId;
+
+    [Write(false)]
+    private DataStore? DataStore { get; set; }
+
+    [Write(false)]
+    [Computed]
+    public Project Project => Project.Get(DataStore, ProjectId);
+
+    [Write(false)]
+    [Computed]
+    public PolicyStatus PolicyStatus => (PolicyStatus)PolicyStatusId;
+
+    [Write(false)]
+    [Computed]
+    public DateTime UpdatedAt => TimeUpdated.ToDateTime();
+
+    // Map PolicyEvaluationStatus to our enum. Our enum is sorted, but the PolicyEvaluationStatus is not.
+    public static PolicyStatus GetFromPolicyEvaluationStatus(PolicyEvaluationStatus? policyEvaluationStatus)
+    {
+        return policyEvaluationStatus switch
+        {
+            PolicyEvaluationStatus.NotApplicable => PolicyStatus.NotApplicable,
+            PolicyEvaluationStatus.Approved => PolicyStatus.Approved,
+            PolicyEvaluationStatus.Rejected => PolicyStatus.Rejected,
+            PolicyEvaluationStatus.Queued => PolicyStatus.Queued,
+            PolicyEvaluationStatus.Running => PolicyStatus.Running,
+            PolicyEvaluationStatus.Broken => PolicyStatus.Broken,
+            _ => PolicyStatus.Unknown,
+        };
+    }
+}

--- a/src/AzureExtension/DataModel/DataObjects/PullRequestPolicyStatus.cs
+++ b/src/AzureExtension/DataModel/DataObjects/PullRequestPolicyStatus.cs
@@ -5,6 +5,7 @@ using Dapper;
 using Dapper.Contrib.Extensions;
 using DevHomeAzureExtension.Helpers;
 using Microsoft.TeamFoundation.Policy.WebApi;
+using Microsoft.TeamFoundation.SourceControl.WebApi;
 using Serilog;
 
 namespace DevHomeAzureExtension.DataModel;
@@ -12,24 +13,39 @@ namespace DevHomeAzureExtension.DataModel;
 [Table("PullRequestPolicyStatus")]
 public class PullRequestPolicyStatus
 {
-    private static readonly Lazy<ILogger> _logger = new(() => Serilog.Log.ForContext("SourceContext", $"DataModel/{nameof(PullRequests)}"));
+    private static readonly Lazy<ILogger> _logger = new(() => Serilog.Log.ForContext("SourceContext", $"DataModel/{nameof(PullRequestPolicyStatus)}"));
 
-    private static readonly ILogger _log = _logger.Value;
+    private static ILogger Log => _logger.Value;
 
     [Key]
     public long Id { get; set; } = DataStore.NoForeignKey;
 
-    // This should suffice as a unique identifier.
+    // This should suffice as a unique identifier, as it is the Project Guid + PullRequestId
     public string ArtifactId { get; set; } = string.Empty;
 
     // Key in Project table
     public long ProjectId { get; set; } = DataStore.NoForeignKey;
 
+    // Key in Repository table
+    public long RepositoryId { get; set; } = DataStore.NoForeignKey;
+
     public long PullRequestId { get; set; } = DataStore.NoForeignKey;
+
+    public string Title { get; set; } = string.Empty;
+
+    public long PolicyStatusId { get; set; } = DataStore.NoForeignKey;
+
+    public string PolicyStatusReason { get; set; } = string.Empty;
+
+    public long PullRequestStatusId { get; set; } = DataStore.NoForeignKey;
+
+    public string TargetBranchName { get; set; } = string.Empty;
+
+    public string HtmlUrl { get; set; } = string.Empty;
 
     public long TimeUpdated { get; set; } = DataStore.NoForeignKey;
 
-    public long PolicyStatusId { get; set; } = DataStore.NoForeignKey;
+    public long TimeCreated { get; set; } = DataStore.NoForeignKey;
 
     public override string ToString() => ArtifactId;
 
@@ -42,11 +58,43 @@ public class PullRequestPolicyStatus
 
     [Write(false)]
     [Computed]
-    public PolicyStatus PolicyStatus => (PolicyStatus)PolicyStatusId;
+    public Repository Repository => Repository.Get(DataStore, RepositoryId);
+
+    [Write(false)]
+    [Computed]
+    public DateTime CreatedAt => TimeCreated.ToDateTime();
 
     [Write(false)]
     [Computed]
     public DateTime UpdatedAt => TimeUpdated.ToDateTime();
+
+    [Write(false)]
+    [Computed]
+    public PolicyStatus PolicyStatus => (PolicyStatus)PolicyStatusId;
+
+    [Write(false)]
+    [Computed]
+    public PullRequestStatus Status => (PullRequestStatus)PullRequestStatusId;
+
+    [Write(false)]
+    [Computed]
+    public bool CompletedOrAbandoned => (Status == PullRequestStatus.Completed) || (Status == PullRequestStatus.Abandoned);
+
+    [Write(false)]
+    [Computed]
+    public bool ActiveOrNotSet => (Status == PullRequestStatus.Active) || (Status == PullRequestStatus.NotSet);
+
+    [Write(false)]
+    [Computed]
+    public bool Waiting => (PolicyStatus == PolicyStatus.Queued) || (PolicyStatus == PolicyStatus.Running);
+
+    [Write(false)]
+    [Computed]
+    public bool Rejected => PolicyStatus <= PolicyStatus.Rejected;
+
+    [Write(false)]
+    [Computed]
+    public bool Approved => PolicyStatus >= PolicyStatus.Approved;
 
     // Map PolicyEvaluationStatus to our enum. Our enum is sorted, but the PolicyEvaluationStatus is not.
     public static PolicyStatus GetFromPolicyEvaluationStatus(PolicyEvaluationStatus? policyEvaluationStatus)
@@ -61,5 +109,81 @@ public class PullRequestPolicyStatus
             PolicyEvaluationStatus.Broken => PolicyStatus.Broken,
             _ => PolicyStatus.Unknown,
         };
+    }
+
+    public static PullRequestPolicyStatus Create(GitPullRequest pullRequest, string artifactId, long projectId, long repositoryId, PolicyStatus policyStatus, string reason, string htmlUrl)
+    {
+        // Get Current status of this pull request, and create a summary capture.
+        return new PullRequestPolicyStatus
+        {
+            ArtifactId = artifactId,
+            ProjectId = projectId,
+            RepositoryId = repositoryId,
+            PullRequestId = pullRequest.PullRequestId,
+            Title = pullRequest.Title,
+            PolicyStatusId = (long)policyStatus,
+            PolicyStatusReason = reason,
+            TargetBranchName = pullRequest.TargetRefName,
+            PullRequestStatusId = (long)pullRequest.Status,
+            HtmlUrl = htmlUrl,
+            TimeCreated = DateTime.UtcNow.ToDataStoreInteger(),
+        };
+    }
+
+    public static PullRequestPolicyStatus? Get(DataStore dataStore, string artifactId)
+    {
+        var sql = @"SELECT * FROM PullRequestPolicyStatus WHERE ArtifactId = @ArtifactId ORDER BY TimeCreated DESC LIMIT 1;";
+        var param = new
+        {
+            ArtifactId = artifactId,
+        };
+
+        Log.Verbose(DataStore.GetSqlLogMessage(sql, param));
+        var pullRequestStatus = dataStore.Connection!.QueryFirstOrDefault<PullRequestPolicyStatus>(sql, param, null);
+        if (pullRequestStatus is not null)
+        {
+            // Add Datastore so this object can make internal queries.
+            pullRequestStatus.DataStore = dataStore;
+        }
+
+        return pullRequestStatus;
+    }
+
+    public static PullRequestPolicyStatus Add(DataStore dataStore, GitPullRequest pullRequest, string artifactId, long projectId, long repositoryId, PolicyStatus policyStatus, string reason, string htmlUrl)
+    {
+        var pullRequestStatus = Create(pullRequest, artifactId, projectId, repositoryId, policyStatus, reason, htmlUrl);
+        pullRequestStatus.Id = dataStore.Connection!.Insert(pullRequestStatus);
+        Log.Debug($"Inserted PullRequestPolicyStatus, Id = {pullRequestStatus.Id}");
+
+        // Remove older records we no longer need.
+        DeleteOutdatedForPullRequest(dataStore, artifactId);
+
+        pullRequestStatus.DataStore = dataStore;
+        return pullRequestStatus;
+    }
+
+    public static void DeleteOutdatedForPullRequest(DataStore dataStore, string artifactId)
+    {
+        // Delete any records beyond the most recent 2.
+        var sql = @"DELETE FROM PullRequestPolicyStatus WHERE ArtifactId = $Id AND Id NOT IN (SELECT Id FROM PullRequestPolicyStatus WHERE ArtifactId = $Id ORDER BY TimeCreated DESC LIMIT 2)";
+        var command = dataStore.Connection!.CreateCommand();
+        command.CommandText = sql;
+        command.Parameters.AddWithValue("$Id", artifactId);
+        Log.Verbose(DataStore.GetCommandLogMessage(sql, command));
+        var rowsDeleted = command.ExecuteNonQuery();
+        Log.Verbose(DataStore.GetDeletedLogMessage(rowsDeleted));
+    }
+
+    public static void DeleteUnreferenced(DataStore dataStore)
+    {
+        // Delete any where the HeadSha has no match in pull requests, as that means either the pull request
+        // no longer exists, or it has pushed new changes and the HeadSha is different, triggering new checks.
+        // In either case it is safe to remove the associated PullRequestPolicyStatus.
+        var sql = @"DELETE FROM PullRequestPolicyStatus WHERE HeadSha NOT IN (SELECT HeadSha FROM PullRequest)";
+        var command = dataStore.Connection!.CreateCommand();
+        command.CommandText = sql;
+        Log.Verbose(DataStore.GetCommandLogMessage(sql, command));
+        var rowsDeleted = command.ExecuteNonQuery();
+        Log.Verbose(DataStore.GetDeletedLogMessage(rowsDeleted));
     }
 }

--- a/src/AzureExtension/DataModel/DataObjects/PullRequests.cs
+++ b/src/AzureExtension/DataModel/DataObjects/PullRequests.cs
@@ -37,7 +37,7 @@ public class PullRequests
 
     public long TimeUpdated { get; set; } = DataStore.NoForeignKey;
 
-    public override string ToString() => DeveloperLogin + "/" + Repository.Name;
+    public override string ToString() => $"{DeveloperLogin}/{Repository.Name}";
 
     [Write(false)]
     private DataStore? DataStore { get; set; }

--- a/src/AzureExtension/DataModel/DataObjects/PullRequests.cs
+++ b/src/AzureExtension/DataModel/DataObjects/PullRequests.cs
@@ -22,7 +22,8 @@ public class PullRequests
     [Key]
     public long Id { get; set; } = DataStore.NoForeignKey;
 
-    public string RepositoryName { get; set; } = string.Empty;
+    // Key in Repository table
+    public long RepositoryId { get; set; } = DataStore.NoForeignKey;
 
     // Key in Project table
     public long ProjectId { get; set; } = DataStore.NoForeignKey;
@@ -36,7 +37,7 @@ public class PullRequests
 
     public long TimeUpdated { get; set; } = DataStore.NoForeignKey;
 
-    public override string ToString() => DeveloperLogin + "/" + RepositoryName;
+    public override string ToString() => DeveloperLogin + "/" + Repository.Name;
 
     [Write(false)]
     private DataStore? DataStore { get; set; }
@@ -44,6 +45,10 @@ public class PullRequests
     [Write(false)]
     [Computed]
     public Project Project => Project.Get(DataStore, ProjectId);
+
+    [Write(false)]
+    [Computed]
+    public Repository Repository => Repository.Get(DataStore, RepositoryId);
 
     [Write(false)]
     [Computed]
@@ -57,11 +62,11 @@ public class PullRequests
     [Computed]
     public DateTime UpdatedAt => TimeUpdated.ToDateTime();
 
-    private static PullRequests Create(string repositoryName, long projectId, string developerLogin, PullRequestView view, string pullRequests)
+    private static PullRequests Create(long repositoryId, long projectId, string developerLogin, PullRequestView view, string pullRequests)
     {
         return new PullRequests
         {
-            RepositoryName = repositoryName,
+            RepositoryId = repositoryId,
             ProjectId = projectId,
             DeveloperLogin = developerLogin,
             Results = pullRequests,
@@ -72,7 +77,7 @@ public class PullRequests
 
     private static PullRequests AddOrUpdate(DataStore dataStore, PullRequests pullRequests)
     {
-        var existing = Get(dataStore, pullRequests.ProjectId, pullRequests.RepositoryName, pullRequests.DeveloperLogin, pullRequests.View);
+        var existing = Get(dataStore, pullRequests.ProjectId, pullRequests.RepositoryId, pullRequests.DeveloperLogin, pullRequests.View);
         if (existing is not null)
         {
             // Update threshold is in case there are many requests in a short period of time.
@@ -110,13 +115,13 @@ public class PullRequests
         return pullRequests ?? new PullRequests();
     }
 
-    public static PullRequests? Get(DataStore dataStore, long projectId, string repositoryName, string developerLogin, PullRequestView view)
+    public static PullRequests? Get(DataStore dataStore, long projectId, long repositoryId, string developerLogin, PullRequestView view)
     {
-        var sql = @"SELECT * FROM PullRequests WHERE ProjectId = @ProjectId AND RepositoryName = @RepositoryName AND DeveloperLogin = @DeveloperLogin AND ViewId = @ViewId;";
+        var sql = @"SELECT * FROM PullRequests WHERE ProjectId = @ProjectId AND RepositoryId = @RepositoryId AND DeveloperLogin = @DeveloperLogin AND ViewId = @ViewId;";
         var param = new
         {
             ProjectId = projectId,
-            RepositoryName = repositoryName,
+            RepositoryId = repositoryId,
             DeveloperLogin = developerLogin,
             ViewId = (long)view,
         };
@@ -140,12 +145,18 @@ public class PullRequests
             return null;
         }
 
-        return Get(dataStore, project.Id, repositoryName, developerLogin, view);
+        var repository = Repository.Get(dataStore, project.Id, repositoryName);
+        if (repository == null)
+        {
+            return null;
+        }
+
+        return Get(dataStore, project.Id, repository.Id, developerLogin, view);
     }
 
-    public static PullRequests GetOrCreate(DataStore dataStore, string repositoryName, long projectId, string developerId, PullRequestView view, string pullRequests)
+    public static PullRequests GetOrCreate(DataStore dataStore, long repositoryId, long projectId, string developerId, PullRequestView view, string pullRequests)
     {
-        var newDeveloperPullRequests = Create(repositoryName, projectId, developerId, view, pullRequests);
+        var newDeveloperPullRequests = Create(repositoryId, projectId, developerId, view, pullRequests);
         return AddOrUpdate(dataStore, newDeveloperPullRequests);
     }
 

--- a/src/AzureExtension/DataModel/Enums/NotificationType.cs
+++ b/src/AzureExtension/DataModel/Enums/NotificationType.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DevHomeAzureExtension.DataModel;
+
+public enum NotificationType
+{
+    Unknown = 0,
+    PullRequestApproved = 1,
+    PullRequestRejected = 2,
+    NewReview = 3,
+}

--- a/src/AzureExtension/DataModel/Enums/PolicyStatus.cs
+++ b/src/AzureExtension/DataModel/Enums/PolicyStatus.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DevHomeAzureExtension.DataModel;
+
+public enum PolicyStatus
+{
+    // Sorted by severity. Most severe is lowest.
+    Broken = 1,
+    Rejected = 2,
+    Queued = 3,
+    Running = 4,
+    Approved = 5,
+    NotApplicable = 6,
+    Unknown = 7,
+}

--- a/src/AzureExtension/DeveloperId/AuthenticationHelper.cs
+++ b/src/AzureExtension/DeveloperId/AuthenticationHelper.cs
@@ -286,7 +286,7 @@ public class AuthenticationHelper : IAuthenticationHelper
 
     public async Task<AuthenticationResult?> ObtainTokenForLoggedInDeveloperAccount(string[] scopes, string loginId)
     {
-        _log.Information($"ObtainTokenForLoggedInDeveloperAccount");
+        _log.Debug($"ObtainTokenForLoggedInDeveloperAccount");
         AuthenticationResult = null;
 
         var existingAccount = await GetDeveloperAccountFromCache(loginId);

--- a/src/AzureExtension/Strings/en-US/Resources.resw
+++ b/src/AzureExtension/Strings/en-US/Resources.resw
@@ -714,4 +714,16 @@
     <value>Launch</value>
     <comment>Text shown in the button to launch Dev Box.</comment>
   </data>
+  <data name="Notifications_Toast_Button.Dismiss" xml:space="preserve">
+    <value>Dismiss</value>
+    <comment>Shown in Toast Notification Dismiss Button</comment>
+  </data>
+  <data name="Notifications_Toast_PullRequestApproved.Title" xml:space="preserve">
+    <value>Approved</value>
+    <comment>Shown in Toast Notification, title line</comment>
+  </data>
+  <data name="Notifications_Toast_PullRequestRejected.Title" xml:space="preserve">
+    <value>Rejected</value>
+    <comment>Shown in Toast Notification, title line</comment>
+  </data>
 </root>

--- a/src/AzureExtension/Widgets/AzurePullRequestsWidget.cs
+++ b/src/AzureExtension/Widgets/AzurePullRequestsWidget.cs
@@ -297,7 +297,7 @@ internal sealed class AzurePullRequestsWidget : AzureWidget
                     // closer-to-correct time than the zero value decades ago, so use DateTime.UtcNow.
                     var dateTicks = workItem["CreationDate"]?.GetValue<long>() ?? DateTime.UtcNow.Ticks;
                     var dateTime = dateTicks.ToDateTime();
-
+                    var creator = DataManager.GetIdentity(workItem["CreatedBy"]?.GetValue<long>() ?? 0L);
                     var item = new JsonObject
                     {
                         { "title", workItem["Title"]?.GetValue<string>() ?? string.Empty },
@@ -305,9 +305,9 @@ internal sealed class AzurePullRequestsWidget : AzureWidget
                         { "status_icon", GetIconForPullRequestStatus(workItem["PolicyStatus"]?.GetValue<string>()) },
                         { "number", element.Key },
                         { "date", TimeSpanHelper.DateTimeOffsetToDisplayString(dateTime, Log) },
-                        { "user", workItem["CreatedBy"]?["Name"]?.GetValue<string>() ?? string.Empty },
+                        { "user", creator.Name },
                         { "branch", workItem["TargetBranch"]?.GetValue<string>().Replace("refs/heads/", string.Empty) },
-                        { "avatar", workItem["CreatedBy"]?["Avatar"]?.GetValue<string>() },
+                        { "avatar", creator.Avatar },
                     };
 
                     itemsArray.Add(item);

--- a/src/AzureExtension/Widgets/AzurePullRequestsWidget.cs
+++ b/src/AzureExtension/Widgets/AzurePullRequestsWidget.cs
@@ -62,13 +62,21 @@ internal sealed class AzurePullRequestsWidget : AzureWidget
 
     private string GetIconForPullRequestStatus(string? prStatus)
     {
-        return prStatus switch
+        prStatus ??= string.Empty;
+        if (Enum.TryParse<PolicyStatus>(prStatus, false, out var policyStatus))
         {
-            "Approved" => IconLoader.GetIconAsBase64("PullRequestApproved.png"),
-            "Waiting" => IconLoader.GetIconAsBase64("PullRequestWaiting.png"),
-            "Rejected" => IconLoader.GetIconAsBase64("PullRequestRejected.png"),
-            _ => IconLoader.GetIconAsBase64("PullRequestReviewNotStarted.png"),
-        };
+            return policyStatus switch
+            {
+                PolicyStatus.Approved => IconLoader.GetIconAsBase64("PullRequestApproved.png"),
+                PolicyStatus.Running => IconLoader.GetIconAsBase64("PullRequestWaiting.png"),
+                PolicyStatus.Queued => IconLoader.GetIconAsBase64("PullRequestWaiting.png"),
+                PolicyStatus.Rejected => IconLoader.GetIconAsBase64("PullRequestRejected.png"),
+                PolicyStatus.Broken => IconLoader.GetIconAsBase64("PullRequestRejected.png"),
+                _ => IconLoader.GetIconAsBase64("PullRequestReviewNotStarted.png"),
+            };
+        }
+
+        return string.Empty;
     }
 
     protected override bool ValidateConfiguration(WidgetActionInvokedArgs args)
@@ -294,7 +302,7 @@ internal sealed class AzurePullRequestsWidget : AzureWidget
                     {
                         { "title", workItem["Title"]?.GetValue<string>() ?? string.Empty },
                         { "url", workItem["HtmlUrl"]?.GetValue<string>() ?? string.Empty },
-                        { "status_icon", GetIconForPullRequestStatus(workItem["Status"]?.GetValue<string>()) },
+                        { "status_icon", GetIconForPullRequestStatus(workItem["PolicyStatus"]?.GetValue<string>()) },
                         { "number", element.Key },
                         { "date", TimeSpanHelper.DateTimeOffsetToDisplayString(dateTime, Log) },
                         { "user", workItem["CreatedBy"]?["Name"]?.GetValue<string>() ?? string.Empty },

--- a/src/AzureExtension/Widgets/AzureQueryListWidget.cs
+++ b/src/AzureExtension/Widgets/AzureQueryListWidget.cs
@@ -300,18 +300,19 @@ internal sealed class AzureQueryListWidget : AzureWidget
                     // closer-to-correct time than the zero value decades ago, so use DateTime.UtcNow.
                     var dateTicks = workItem["System.ChangedDate"]?.GetValue<long>() ?? DateTime.UtcNow.Ticks;
                     var dateTime = dateTicks.ToDateTime();
-
+                    var creator = DataManager.GetIdentity(workItem["System.CreatedBy"]?.GetValue<long>() ?? 0L);
+                    var workItemType = DataManager.GetWorkItemType(workItem["System.WorkItemType"]?.GetValue<long>() ?? 0L);
                     var item = new JsonObject
                     {
                         { "title", workItem["System.Title"]?.GetValue<string>() ?? string.Empty },
                         { "url", workItem[AzureDataManager.WorkItemHtmlUrlFieldName]?.GetValue<string>() ?? string.Empty },
-                        { "icon", GetIconForType(workItem["System.WorkItemType"]?["Name"]?.GetValue<string>()) },
+                        { "icon", GetIconForType(workItemType.Name) },
                         { "status_icon", GetIconForStatusState(workItem["System.State"]?.GetValue<string>()) },
                         { "number", element.Key },
                         { "date", TimeSpanHelper.DateTimeOffsetToDisplayString(dateTime, Log) },
-                        { "user", workItem["System.CreatedBy"]?["Name"]?.GetValue<string>() ?? string.Empty },
+                        { "user", creator.Avatar },
                         { "status", workItem["System.State"]?.GetValue<string>() ?? string.Empty },
-                        { "avatar", workItem["System.CreatedBy"]?["Avatar"]?.GetValue<string>() ?? string.Empty },
+                        { "avatar", creator.Avatar },
                     };
 
                     itemsArray.Add(item);

--- a/test/AzureExtension/DataStore/DataObjectTests.cs
+++ b/test/AzureExtension/DataStore/DataObjectTests.cs
@@ -345,9 +345,11 @@ public partial class DataStoreTests
         var org = Organization.GetOrCreate(dataStore, new Uri("https://dev.azure.com/organization/"));
         Assert.IsNotNull(org);
         dataStore.Connection.Insert(new Project { Name = "project", InternalId = "11", OrganizationId = org.Id });
+        dataStore.Connection.Insert(new Repository { Name = "repository1", InternalId = "21", CloneUrl = "https://organization/project/_git/repository1/", ProjectId = 1 });
+        dataStore.Connection.Insert(new Repository { Name = "repository2", InternalId = "22", CloneUrl = "https://organization/project/_git/repository2/", ProjectId = 1 });
 
-        var p1 = PullRequests.GetOrCreate(dataStore, "repository1", 1, "foo@bar", PullRequestView.Mine, "Results");
-        var p2 = PullRequests.GetOrCreate(dataStore, "repository2", 1, "foo@bar", PullRequestView.Mine, "Results");
+        var p1 = PullRequests.GetOrCreate(dataStore, 1, 1, "foo@bar", PullRequestView.Mine, "Results");
+        var p2 = PullRequests.GetOrCreate(dataStore, 2, 1, "foo@bar", PullRequestView.Mine, "Results");
         tx.Commit();
 
         // Verify retrieval and input into data objects.
@@ -358,15 +360,15 @@ public partial class DataStoreTests
             var pull = PullRequests.Get(dataStore, i);
             Assert.IsNotNull(pull);
             Assert.AreEqual($"foo@bar", pull.DeveloperLogin);
-            Assert.AreEqual($"repository{i}", pull.RepositoryName);
+            Assert.AreEqual($"repository{i}", pull.Repository.Name);
             Assert.AreEqual("organization", pull.Project.Organization.Name);
             Assert.AreEqual(PullRequestView.Mine, pull.View);
-            TestContext?.WriteLine($"  Name: {pull.RepositoryName}  Results: {pull.Results}");
+            TestContext?.WriteLine($"  Name: {pull.Repository.Name}  Results: {pull.Results}");
         }
 
         var findPull = PullRequests.Get(dataStore, "organization", "project", "repository2", "foo@bar", PullRequestView.Mine);
         Assert.IsNotNull(findPull);
-        Assert.AreEqual("repository2", findPull.RepositoryName);
+        Assert.AreEqual("repository2", findPull.Repository.Name);
         Assert.AreEqual(PullRequestView.Mine, findPull.View);
         Assert.AreEqual("project", findPull.Project.Name);
     }

--- a/test/AzureExtension/DataStore/DataObjectTests.cs
+++ b/test/AzureExtension/DataStore/DataObjectTests.cs
@@ -372,4 +372,57 @@ public partial class DataStoreTests
         Assert.AreEqual(PullRequestView.Mine, findPull.View);
         Assert.AreEqual("project", findPull.Project.Name);
     }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void ReadAndWriteStatusAndNotification()
+    {
+        using var dataStore = new DataStore("TestStore", TestHelpers.GetDataStoreFilePath(TestOptions), TestOptions.DataStoreOptions.DataStoreSchema!);
+        Assert.IsNotNull(dataStore);
+        dataStore.Create();
+        Assert.IsNotNull(dataStore.Connection);
+
+        using var tx = dataStore.Connection.BeginTransaction();
+        var org = Organization.GetOrCreate(dataStore, new Uri("https://dev.azure.com/organization/"));
+        Assert.IsNotNull(org);
+        dataStore.Connection.Insert(new Project { Name = "project", InternalId = "11", OrganizationId = org.Id });
+        dataStore.Connection.Insert(new Repository { Name = "repository", InternalId = "21", CloneUrl = "https://organization/project/_git/repository/", ProjectId = 1 });
+
+        var artifactId = "vstfs:///CodeReview/CodeReviewId/foo/47";
+        var title = "Pull Request Test";
+        var url = "https://organization/project/_git/repository/pullrequest/47";
+        dataStore.Connection.Insert(new PullRequestPolicyStatus
+        {
+            ArtifactId = artifactId,
+            ProjectId = 1,
+            RepositoryId = 1,
+            PullRequestId = 47,
+            Title = title,
+            PolicyStatusId = 2,
+            PolicyStatusReason = "Build Fail",
+            TargetBranchName = "refs/heads/main",
+            PullRequestStatusId = 1,
+            HtmlUrl = url,
+            TimeCreated = DateTime.UtcNow.ToDataStoreInteger(),
+        });
+
+        var prStatus = PullRequestPolicyStatus.Get(dataStore, artifactId);
+        Assert.IsNotNull(prStatus);
+
+        TestContext?.WriteLine($"  PR: {prStatus.PullRequestId} Status: {prStatus.PolicyStatusId}: {prStatus.PolicyStatus} - {prStatus.PolicyStatusReason}");
+        Assert.AreEqual(url, prStatus.HtmlUrl);
+        Assert.AreEqual(PolicyStatus.Rejected, prStatus.PolicyStatus);
+        Assert.AreEqual(artifactId, prStatus.ArtifactId);
+
+        // Create notification from PR Status
+        var notification = Notification.Create(dataStore, prStatus, NotificationType.PullRequestRejected);
+        Assert.IsNotNull(notification);
+        Assert.AreEqual(title, notification.Title);
+        Assert.AreEqual(1, notification.RepositoryId);
+        Assert.AreEqual(1, notification.ProjectId);
+        Assert.AreEqual(PolicyStatus.Rejected.ToString(), notification.Result);
+        Assert.AreEqual(url, notification.HtmlUrl);
+        TestContext?.WriteLine($"  {notification.Title}");
+        TestContext?.WriteLine($"  {notification.Description}");
+    }
 }


### PR DESCRIPTION
## Summary of the pull request
Adds toast notifications for when a recent developer's pull request is either Rejected by policy or passes all policy and is Approved.

![image](https://github.com/user-attachments/assets/c115443c-1acb-4054-b88e-20e092519acd)

Also adds Pull Request policy status to the Pull Request data for all pull requests, which can be utilized by Pull Request widget for displaying status icons. The display status change is not part of this PR, but this PR enables it.
  
## References and relevant issues
#111 

## Detailed description of the pull request / Additional comments
Changes:
* Added new DataModel objects for PullRequestPolicyStatus and Notifications.
* Updated pull request fetching code to utilize Repository information.
* Added updater for checking for developer pull request changes. This relies on the Repository cache being updated to discover the developer's active repositories and can be delayed the first time by several minutes.
* Added Notification handling and pushing after updating the developer's pull requests. Notification code and display logic is very similar to that of the GitHub extension and has similar behavior.
* Updated and refactored Pull Request fetching behavior to be easier to read and process.
* Updated the data model for Pull Request to use Id for Identity and WorkItemType, which reduces the record size significantly.
* Added data manager interface methods to fetch WorkItemType and Identity by Id.
* Updated Widgets to have access to the new Pull Request Policy status.
* Added tests for Notifications and PullRequestStatus objects.

Notes:
* Only a developer's own pull requests will receive notifications. This is for developer accounts the user has added via the extension.
* Pull Requests older than 14 days are considered not notification worthy so as to prevent notification spam of ancient pull requests. This is an easily changeable constant should we desire more/less retention.
* A pull request's update time is considered to be the most recent commit push or its creation date, whichever is newer. Pull requests in active development will have notifications (as long as it's been pushed within the last 14 days). Pull requests that have been sitting around for longer than that will not have notifications.
* Only notifications for policy evaluation failures or approvals are created. For example, a pull request that has had a rejection from a required reviewer will display a notification, or one that fails a build policy check. A pull request that is running a policy or waiting for approval will not give notifications unless some other policy check fails.

## Validation steps performed
* Verified widgets still work as expected.
* All Data Model tests passed, including the new one for notifications and pull request policy status.
* Lots of manual verification with own pull request and test pull requests that the data retention and notification display behavior is correct.

## PR checklist
- [x] Closes #111
- [x] Tests added/passed
- [x] Documentation updated
