### PR TITLE
Fix incorrect resource identifiers in QueryTilesConfigurationTemplate

### DIFF
--- a/src/AzureExtension/Widgets/Templates/AzureQueryTilesConfigurationTemplate.json
+++ b/src/AzureExtension/Widgets/Templates/AzureQueryTilesConfigurationTemplate.json
@@ -60,9 +60,9 @@
         },
         {
           "type": "Input.Text",
-          "placeholder": "%Widget_Template/QueryTitlePlaceholder%",
+          "placeholder": "%Widget_Template/WidgetTitlePlaceholder%",
           "id": "tileTitle${$index}",
-          "label": "%Widget_Template/QueryTitleLabel%",
+          "label": "%Widget_Template/WidgetTitleLabel%",
           "value": "${title}"
         },
         {


### PR DESCRIPTION
## Summary of the pull request
The QueryTilesConfigurationTemplate was using resource identifiers that had been renamed but were not updated to the new name. This resulted in a failure to localize the template and the template identifiers showing up in the configuration page instead of the correct localized strings.

## References and relevant issues
#255 

## Detailed description of the pull request / Additional comments
* Updated the template to use the correct resource identifiers.

## Validation steps performed
* Verified templates correctly localized with the change.

## PR checklist
- [x] Closes #255
- [x] Tests added/passed
- [x] Documentation updated
