### PR TITLE
Use .NET8 for CI build

### DIFF
--- a/.github/workflows/ADOExt-CI.yml
+++ b/.github/workflows/ADOExt-CI.yml
@@ -15,7 +15,7 @@ jobs:
         configuration: [Release, Debug]
         platform: [x64, arm64]
         os: [windows-latest]
-        dotnet-version: ['6.0.x']
+        dotnet-version: ['8.0.x']
         exclude:
         - configuration: Debug
           platform: x64


### PR DESCRIPTION
## Summary of the pull request
CI builds were still using .Net 6, use .Net 8 instead.