### PR TITLE
Limit size of API key input on adaptive card text box

### DIFF
--- a/src/AzureExtension/QuickStartPlayground/OpenAIDevContainerQuickStartProjectProvider.cs
+++ b/src/AzureExtension/QuickStartPlayground/OpenAIDevContainerQuickStartProjectProvider.cs
@@ -88,6 +88,7 @@ public sealed partial class OpenAIDevContainerQuickStartProjectProvider : DevCon
             ""placeholder"": """ + Resources.GetResource(@"QuickstartPlayground_OpenAI_AdaptiveCard_APIKey_Input") + @""",
             ""tooltip"": """ + Resources.GetResource(@"QuickstartPlayground_OpenAI_AdaptiveCard_APIKey_Input") + @""",
             ""isRequired"": true,
+            ""maxLength"": 500,
             ""errorMessage"": """ + Resources.GetResource(@"QuickstartPlayground_OpenAI_AdaptiveCard_APIKey_Input_ErrorMsg") + @""",
             ""style"": ""Password"",
             ""id"": ""Key""

--- a/src/AzureExtension/QuickStartPlayground/OpenAIDevContainerQuickStartProjectProvider.cs
+++ b/src/AzureExtension/QuickStartPlayground/OpenAIDevContainerQuickStartProjectProvider.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Serialization;
 using DevHomeAzureExtension.Contracts;
 using DevHomeAzureExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
+using Serilog;
 using Windows.Foundation;
 
 namespace DevHomeAzureExtension.QuickStartPlayground;
@@ -31,6 +32,8 @@ public sealed partial class OpenAIDevContainerQuickStartProjectProvider : DevCon
 
     public sealed partial class AIProviderInitializationUIController : IExtensionAdaptiveCardSession2
     {
+        private readonly ILogger _log = Serilog.Log.ForContext("SourceContext", nameof(AIProviderInitializationUIController));
+
         public event TypedEventHandler<IExtensionAdaptiveCardSession2, ExtensionAdaptiveCardSessionStoppedEventArgs>? Stopped;
 
         private readonly IAzureOpenAIService _azureOpenAIService;
@@ -118,50 +121,78 @@ public sealed partial class OpenAIDevContainerQuickStartProjectProvider : DevCon
 
         public unsafe IAsyncOperation<ProviderOperationResult> OnAction(string action, string inputs)
         {
+            ProviderOperationResult result;
+            var operationCanceled = false;
+
+            _log.Information("OnAction: {action}", action);
+
             return Task.Run(() =>
             {
-                var adaptiveCardPayload = JsonSerializer.Deserialize(action, AIAdaptiveCardPayloadSourceGeneration.Default.AIAdaptiveCardActionPayload);
-                if (adaptiveCardPayload is not null)
+                try
                 {
-                    if (adaptiveCardPayload.IsSubmitAction)
+                    var adaptiveCardPayload = JsonSerializer.Deserialize(action, AIAdaptiveCardPayloadSourceGeneration.Default.AIAdaptiveCardActionPayload);
+                    if (adaptiveCardPayload is not null)
                     {
-                        var inputPayload = JsonSerializer.Deserialize(inputs, AIAdaptiveCardPayloadSourceGeneration.Default.AIAdaptiveCardInputPayload);
-                        if (inputPayload is not null && !string.IsNullOrEmpty(inputPayload.Key))
+                        if (adaptiveCardPayload.IsSubmitAction)
                         {
-                            fixed (char* keyPtr = inputPayload.Key)
+                            var inputPayload = JsonSerializer.Deserialize(inputs, AIAdaptiveCardPayloadSourceGeneration.Default.AIAdaptiveCardInputPayload);
+                            if (inputPayload is not null && !string.IsNullOrEmpty(inputPayload.Key))
                             {
-                                SecureString secureString = new(keyPtr, inputPayload.Key.Length);
-                                _azureOpenAIService.AICredentialService.SaveCredentials(LoginId, LoginId, secureString);
+                                fixed (char* keyPtr = inputPayload.Key)
+                                {
+                                    SecureString secureString = new(keyPtr, inputPayload.Key.Length);
+                                    _azureOpenAIService.AICredentialService.SaveCredentials(LoginId, LoginId, secureString);
+                                }
+
+                                _azureOpenAIService.InitializeAIClient();
+                                result = new ProviderOperationResult(ProviderOperationStatus.Success, null, string.Empty, string.Empty);
                             }
-
-                            _azureOpenAIService.InitializeAIClient();
-
-                            // Inform Dev Home that we are done initializing AI provider.
-                            var result = new ProviderOperationResult(ProviderOperationStatus.Success, null, string.Empty, string.Empty);
-                            Stopped?.Invoke(this, new(result, string.Empty));
-                            return result;
+                            else
+                            {
+                                _log.Error("API Key is null");
+                                result = new ProviderOperationResult(ProviderOperationStatus.Failure, null, Resources.GetResource(@"QuickstartPlayground_OpenAI_AdaptiveCard_InvalidAPIKey"), "API Key is null");
+                            }
+                        }
+                        else if (adaptiveCardPayload.IsCancelAction)
+                        {
+                            // We will inform Dev Home using the stopped event that the user canceled
+                            // but the result of OnAction is we successfully handled the user clicking cancel.
+                            _log.Information("User canceled the operation.");
+                            operationCanceled = true;
+                            result = new ProviderOperationResult(ProviderOperationStatus.Success, null, string.Empty, string.Empty);
                         }
                         else
                         {
-                            return new ProviderOperationResult(ProviderOperationStatus.Failure, null, Resources.GetResource(@"QuickstartPlayground_OpenAI_AdaptiveCard_InvalidAPIKey"), "API Key is null");
+                            _log.Error("action Id is null");
+                            result = new ProviderOperationResult(ProviderOperationStatus.Failure, null, Resources.GetResource(@"QuickstartPlayground_OpenAI_AdaptiveCard_InvalidAPIKey"), "action Id is null");
                         }
-                    }
-                    else if (adaptiveCardPayload.IsCancelAction)
-                    {
-                        // Inform Dev Home using the stopped event that the user canceled,
-                        // but the result of OnAction is we successfully handled the user clicking cancel.
-                        Stopped?.Invoke(this, new(new ProviderOperationResult(ProviderOperationStatus.Failure, new OperationCanceledException(), string.Empty, string.Empty), string.Empty));
-                        return new ProviderOperationResult(ProviderOperationStatus.Success, null, string.Empty, string.Empty);
                     }
                     else
                     {
-                        return new ProviderOperationResult(ProviderOperationStatus.Failure, null, Resources.GetResource(@"QuickstartPlayground_OpenAI_AdaptiveCard_InvalidAPIKey"), "action Id is null");
+                        _log.Error("adaptiveCardPayload is null");
+                        result = new ProviderOperationResult(ProviderOperationStatus.Failure, null, Resources.GetResource(@"QuickstartPlayground_OpenAI_AdaptiveCard_InvalidAPIKey"), "adaptiveCardPayload is null");
                     }
+                }
+                catch (Exception ex)
+                {
+                    _log.Error("Failed to process action: {ex}", ex);
+                    result = new ProviderOperationResult(ProviderOperationStatus.Failure, ex, ex.Message, string.Empty);
+                }
+
+                // Inform Dev Home that we are done initializing AI provider.
+                if (operationCanceled)
+                {
+                    _log.Information("Notifying Dev Home that AI provider initialization has been canceled");
+                    var cancellationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, new OperationCanceledException(), string.Empty, string.Empty);
+                    Stopped?.Invoke(this, new(cancellationResult, string.Empty));
                 }
                 else
                 {
-                    return new ProviderOperationResult(ProviderOperationStatus.Failure, null, Resources.GetResource(@"QuickstartPlayground_OpenAI_AdaptiveCard_InvalidAPIKey"), "adaptiveCardPayload is null");
+                    _log.Information("Notifying Dev Home that AI provider initialization is complete");
+                    Stopped?.Invoke(this, new(result, string.Empty));
                 }
+
+                return result;
             }).AsAsyncOperation();
         }
 


### PR DESCRIPTION
## Summary of the pull request
This change adds a `maxLength` parameter to the text box that handles the OpenAI API key and addresses some missing exception handling and logging.

## References and relevant issues

## Detailed description of the pull request / Additional comments
We noticed that the adaptive card for handling the API key was not specifying a max length, and so a user could insert a potentially long (and therefore invalid) string which would be passed down to the credential maanger APIs. Those APIs have a documented limit on the size of the data they will accept, and so the OS returned an error which manifests as an exception, which went unhandled because the `OnAction` method didn't have exception handling.

This change adds a limit to the amount of text that can be supplied through this text box. I couldn't find an online source specifying the expected length of the key, so I picked a value which we can adjust if needed. The change also adds error handling, since the failures from the platform API in this scenario weren't being caught. I also noticed that we were not signaling Dev Home in some of the possible error paths, so I moved the logic to do this into a central place. For those error scenarios, we technically do not have UX that exposes the diagnostics back to the user, so I put the data in the logs for now. 

## Validation steps performed
Manual testing of the following scenarios:
* The golden path case for entering in a valid API key
* Ensured that the input is correctly sized if the user attempts to paste in a string much larger than the limit
* Validated that the cancelation behavior continues to function as expected
* Commented out the limit and verified that the exception is correctly handled now
* Visually verified the new logs

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
