### PR TITLE
[DevBox] Start the Dev Box while configuring

### DIFF
--- a/src/AzureExtension/DevBox/Constants.cs
+++ b/src/AzureExtension/DevBox/Constants.cs
@@ -82,7 +82,7 @@ public static class Constants
     /// </summary>
     public const uint IndefiniteProgress = 0;
 
-    public static readonly TimeSpan OneMinutePeriod = TimeSpan.FromMinutes(1);
+    public static readonly TimeSpan HalfMinutePeriod = TimeSpan.FromSeconds(30);
 
     public static readonly TimeSpan ThreeMinutePeriod = TimeSpan.FromMinutes(3);
 

--- a/src/AzureExtension/DevBox/DevBoxInstance.cs
+++ b/src/AzureExtension/DevBox/DevBoxInstance.cs
@@ -623,7 +623,7 @@ public class DevBoxInstance : IComputeSystem, IComputeSystem2
 
     public IApplyConfigurationOperation CreateApplyConfigurationOperation(string configuration)
     {
-        return new WingetConfigWrapper(configuration, DevBoxState.Uri, _devBoxManagementService, AssociatedDeveloperId, _log, GetState(), ConnectAsync);
+        return new WingetConfigWrapper(this, configuration, _devBoxManagementService, _log);
     }
 
     // Unsupported operations

--- a/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
+++ b/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
@@ -339,15 +339,10 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
         {
             return;
         }
-        else if (response.PowerState == Constants.DevBoxPowerStates.Unknown ||
-            response.PowerState == Constants.DevBoxPowerStates.Deallocated)
-        {
-            throw new InvalidOperationException(Resources.GetResource(DevBoxErrorStateKey));
-        }
 
         // Start the Dev Box
         var startURI = new Uri($"{_baseAPI}:start?{Constants.APIVersion}");
-        var startRequest = await _managementService.HttpsRequestToDataPlane(startURI, _devId, HttpMethod.Post, null);
+        await _managementService.HttpsRequestToDataPlane(startURI, _devId, HttpMethod.Post, null);
         _log.Information("Starting the dev box to apply configuration");
 
         // Notify the user

--- a/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
+++ b/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
@@ -347,10 +347,9 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
         // Notify the user
         ConfigurationSetStateChanged?.Invoke(this, new(new(ConfigurationSetChangeEventType.SetStateChanged, ConfigurationSetState.StartingDevice, ConfigurationUnitState.Unknown, null, null)));
 
-        // Wait for the Dev Box to start with an initial wait of 3 minutes and a max of 15 minutes
+        // Wait for the Dev Box to start with a timeout of 15 minutes
         var delay = TimeSpan.FromSeconds(30);
-        var waitTimeLeft = TimeSpan.FromMinutes(12);
-        await Task.Delay(TimeSpan.FromMinutes(3));
+        var waitTimeLeft = TimeSpan.FromMinutes(15);
 
         // Wait for the Dev Box to start, polling every 30 seconds
         while ((waitTimeLeft > TimeSpan.Zero) && (_devBox.GetState() != ComputeSystemState.Running))

--- a/src/AzureExtension/Services/DevBox/TimeSpanService.cs
+++ b/src/AzureExtension/Services/DevBox/TimeSpanService.cs
@@ -31,7 +31,7 @@ public class TimeSpanService : ITimeSpanService
             case DevBoxActionToPerform.Create:
                 return DevBoxConstants.ThreeMinutePeriod;
             default:
-                return DevBoxConstants.OneMinutePeriod;
+                return DevBoxConstants.HalfMinutePeriod;
         }
     }
 }

--- a/src/AzureExtension/Strings/en-US/Resources.resw
+++ b/src/AzureExtension/Strings/en-US/Resources.resw
@@ -554,9 +554,9 @@
     <value>No default user logged in. Please login from the Settings page.</value>
     <comment>Error shown when no user name is sent to the extension.</comment>
   </data>
-  <data name="DevBox_NotRunningFailedKey" xml:space="preserve">
-    <value>The Dev Box isn't running. Please start the Dev Box and try again.</value>
-    <comment>Error shown when the operation fails due to the Dev Box not currently running.</comment>
+  <data name="DevBox_ErrorStateKey" xml:space="preserve">
+    <value>The Dev Box isn't in a valid state.</value>
+    <comment>Error shown when the operation fails due to the Dev Box not being in a valid state.</comment>
   </data>
   <data name="DevBox_AdaptiveCard_ResumeText" xml:space="preserve">
     <value>Resume</value>

--- a/src/AzureExtension/Strings/en-US/Resources.resw
+++ b/src/AzureExtension/Strings/en-US/Resources.resw
@@ -554,8 +554,12 @@
     <value>No default user logged in. Please login from the Settings page.</value>
     <comment>Error shown when no user name is sent to the extension.</comment>
   </data>
+  <data name="DevBox_ErrorStartKey" xml:space="preserve">
+    <value>The Dev Box {0} couldn't be started</value>
+    <comment>Error shown when the start operation fails on the Dev Box.</comment>
+  </data>
   <data name="DevBox_ErrorStateKey" xml:space="preserve">
-    <value>The Dev Box isn't in a valid state</value>
+    <value>The Dev Box {0} isn't in a valid state</value>
     <comment>Error shown when the operation fails due to the Dev Box not being in a valid state.</comment>
   </data>
   <data name="DevBox_AdaptiveCard_ResumeText" xml:space="preserve">

--- a/src/AzureExtension/Strings/en-US/Resources.resw
+++ b/src/AzureExtension/Strings/en-US/Resources.resw
@@ -551,7 +551,7 @@
     <comment>Title text of the dialog asking to log in to the Dev Box.</comment>
   </data>
   <data name="DevBox_NoDefaultUserFailKey" xml:space="preserve">
-    <value>No default user logged in. Please login from the Settings page.</value>
+    <value>No default user logged in. Please login from the Settings page to view the associated Dev Boxes.</value>
     <comment>Error shown when no user name is sent to the extension.</comment>
   </data>
   <data name="DevBox_ErrorStartKey" xml:space="preserve">

--- a/src/AzureExtension/Strings/en-US/Resources.resw
+++ b/src/AzureExtension/Strings/en-US/Resources.resw
@@ -555,7 +555,7 @@
     <comment>Error shown when no user name is sent to the extension.</comment>
   </data>
   <data name="DevBox_ErrorStateKey" xml:space="preserve">
-    <value>The Dev Box isn't in a valid state.</value>
+    <value>The Dev Box isn't in a valid state</value>
     <comment>Error shown when the operation fails due to the Dev Box not being in a valid state.</comment>
   </data>
   <data name="DevBox_AdaptiveCard_ResumeText" xml:space="preserve">


### PR DESCRIPTION
## Summary of the pull request
The PR addresses the issue where the Dev Box was no running while trying to apply a configuration. The Dev Box is now started, instead of erroring out.

##Before
![image](https://github.com/user-attachments/assets/808eb7c0-3c29-4a61-ae89-a29a65122fa3)

##After
![image](https://github.com/user-attachments/assets/26a946ad-6ab8-447a-b222-80f439eb3f36)

## Validation steps performed
Manually

## PR checklist
- [ ] Closes #https://github.com/microsoft/devhome/issues/3669

