### PR TITLE
Update Package display name

### DIFF
--- a/src/AzureExtensionServer/Package-Can.appxmanifest
+++ b/src/AzureExtensionServer/Package-Can.appxmanifest
@@ -2,7 +2,7 @@
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/templatestudio" xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" IgnorableNamespaces="uap uap3 rescap genTemplate">
   <Identity Name="Microsoft.Windows.DevHomeAzureExtension.Canary" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
   <Properties>
-    <DisplayName>Dev Home Azure Extension (Canary)</DisplayName>
+    <DisplayName>ms-resource:AppDisplayNameCanary</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>

--- a/src/AzureExtensionServer/Package-Dev.appxmanifest
+++ b/src/AzureExtensionServer/Package-Dev.appxmanifest
@@ -2,7 +2,7 @@
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/templatestudio" xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" IgnorableNamespaces="uap uap3 rescap genTemplate">
   <Identity Name="Microsoft.Windows.DevHomeAzureExtension.Dev" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
   <Properties>
-    <DisplayName>Dev Home Azure Extension (Dev)</DisplayName>
+    <DisplayName>ms-resource:AppDisplayNameDev</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>

--- a/src/AzureExtensionServer/Package.appxmanifest
+++ b/src/AzureExtensionServer/Package.appxmanifest
@@ -2,7 +2,7 @@
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/templatestudio" xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" IgnorableNamespaces="uap uap3 rescap genTemplate">
   <Identity Name="Microsoft.Windows.DevHomeAzureExtension" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
   <Properties>
-    <DisplayName>Dev Home Azure Extension</DisplayName>
+    <DisplayName>ms-resource:AppDisplayNameStable</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>


### PR DESCRIPTION
## Summary of the pull request
This pull request adds the "(Preview)" label back to Dev Home Azure Extension once installed. Before, the PackageDisplayName (used on the Installed SettingsCard titles) was hardcoded. Now, it's set to the display name string in `src\AzureExtension\Strings\en-US\Resources.resw`

This PR also updates the Canary and Dev PackageDisplayNames to their respective resource strings.

## References and relevant issues
#265

Before:
- When Dev Home Azure Extension (Preview) was installed, the "(Preview)" label disappeared

After:
![image](https://github.com/user-attachments/assets/f76c489f-e596-43a8-bebe-93aa0b4f3cba)

## Detailed description of the pull request / Additional comments

## Validation steps performed (locally)
Validated locally

## PR checklist
- [ ] Closes #265 
- [ ] Tests added/passed
- [ ] Documentation updated
