### PR TITLE
Update ADOExt-CI.yml pipeline actions

### DIFF
--- a/.github/workflows/ADOExt-CI.yml
+++ b/.github/workflows/ADOExt-CI.yml
@@ -23,7 +23,7 @@ jobs:
           platform: arm64
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         clean: true
 

--- a/.github/workflows/ADOExt-CI.yml
+++ b/.github/workflows/ADOExt-CI.yml
@@ -23,19 +23,19 @@ jobs:
           platform: arm64
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
       with:
         clean: true
 
     - name: Setup .NET SDK ${{ matrix.dotnet-version }}
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
       env:
         NUGET_AUTH_TOKEN: ${{ secrets.GPR_READ_TOKEN }}
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v2
       with:
         vs-version: '17.5'
 


### PR DESCRIPTION
## Summary of the pull request
Update GitHub actions to ones that use the supported Node20 instead of unsupported Node16.
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

Mirrors https://github.com/microsoft/devhome/pull/3721