### PR TITLE
Simplifying WAM errors

### DIFF
--- a/src/AzureExtension/DevBox/Constants.cs
+++ b/src/AzureExtension/DevBox/Constants.cs
@@ -221,6 +221,12 @@ public static class Constants
 
     public const string DevBoxUnableToCheckTaskbarPinning = "DevBox_UnableToCheckTaskbarPinningStatus";
 
+    public const string DevBoxWAMError1 = "DevBox_WAMError1";
+
+    public const string DevBoxWAMError2 = "DevBox_WAMError2";
+
+    public const string DevBoxWAMErrorRefer = "DevBox_WAMErrorRefer";
+
     /// <summary>
     /// Resource key for the error message to show with the log location for the configuration flow.
     /// </summary>

--- a/src/AzureExtension/DevBox/DevBoxProvider.cs
+++ b/src/AzureExtension/DevBox/DevBoxProvider.cs
@@ -180,6 +180,10 @@ public class DevBoxProvider : IComputeSystemProvider
                 {
                     errorMessage = Resources.GetResource(Constants.NoDefaultUserFailKey);
                 }
+                else if (ex.Message.Contains("WAM Error"))
+                {
+                    errorMessage = SimplifyWAMError(ex.Message);
+                }
                 else
                 {
                     errorMessage = Resources.GetResource(Constants.RetrievalFailKey, developerId.LoginId) + ex.Message;
@@ -189,6 +193,24 @@ public class DevBoxProvider : IComputeSystemProvider
                 return new ComputeSystemsResult(ex, errorMessage, string.Empty);
             }
         }).AsAsyncOperation();
+    }
+
+    // Handle common WAM errors
+    // Reference: https://learn.microsoft.com/en-us/entra/msal/dotnet/advanced/exceptions/wam-errors
+    private string SimplifyWAMError(string errorMessage)
+    {
+        if (errorMessage.Contains("3399614467"))
+        {
+            return Constants.DevBoxWAMError1 + "\n" + Constants.DevBoxWAMErrorRefer;
+        }
+        else if (errorMessage.Contains("3399614476"))
+        {
+            return Constants.DevBoxWAMError2 + "\n" + Constants.DevBoxWAMErrorRefer;
+        }
+        else
+        {
+            return errorMessage + "\n" + Constants.DevBoxWAMErrorRefer;
+        }
     }
 
     public ICreateComputeSystemOperation? CreateCreateComputeSystemOperation(IDeveloperId developerId, string inputJson)

--- a/src/AzureExtension/DevBox/DevBoxProvider.cs
+++ b/src/AzureExtension/DevBox/DevBoxProvider.cs
@@ -201,15 +201,15 @@ public class DevBoxProvider : IComputeSystemProvider
     {
         if (errorMessage.Contains("3399614467"))
         {
-            return Constants.DevBoxWAMError1 + "\n" + Constants.DevBoxWAMErrorRefer;
+            return Constants.DevBoxWAMError1 + "\n" + Resources.GetResource(Constants.DevBoxWAMErrorRefer);
         }
         else if (errorMessage.Contains("3399614476"))
         {
-            return Constants.DevBoxWAMError2 + "\n" + Constants.DevBoxWAMErrorRefer;
+            return Constants.DevBoxWAMError2 + "\n" + Resources.GetResource(Constants.DevBoxWAMErrorRefer);
         }
         else
         {
-            return errorMessage + "\n" + Constants.DevBoxWAMErrorRefer;
+            return errorMessage + "\n" + Resources.GetResource(Constants.DevBoxWAMErrorRefer);
         }
     }
 

--- a/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
+++ b/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
@@ -337,7 +337,6 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
         var startResult = (await _devBox.StartAsync(string.Empty)).Result;
         if (startResult.Status != ProviderOperationStatus.Success)
         {
-            _log.Error(startResult.ToStringInvariant(), "Unable to start the dev box");
             throw new InvalidOperationException(Resources.GetResource(DevBoxErrorStartKey, _devBox.DisplayName));
         }
 

--- a/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
+++ b/src/AzureExtension/DevBox/Helpers/WingetConfigWrapper.cs
@@ -333,15 +333,12 @@ public class WingetConfigWrapper : IApplyConfigurationOperation, IDisposable
         }
 
         // Start the Dev Box
-        try
+        _log.Information("Starting the dev box to apply configuration");
+        var startResult = (await _devBox.StartAsync(string.Empty)).Result;
+        if (startResult.Status != ProviderOperationStatus.Success)
         {
-            _log.Information("Starting the dev box to apply configuration");
-            var startResult = await _devBox.StartAsync(string.Empty);
-        }
-        catch (Exception ex)
-        {
-            _log.Error(ex, "Unable to start the dev box");
-            throw new InvalidOperationException(Resources.GetResource(DevBoxErrorStateKey, _devBox.DisplayName));
+            _log.Error(startResult.ToStringInvariant(), "Unable to start the dev box");
+            throw new InvalidOperationException(Resources.GetResource(DevBoxErrorStartKey, _devBox.DisplayName));
         }
 
         // Notify the user

--- a/src/AzureExtension/Strings/en-US/Resources.resw
+++ b/src/AzureExtension/Strings/en-US/Resources.resw
@@ -735,15 +735,15 @@
     <comment>Shown in Widget</comment>
   </data>
   <data name="DevBox_WAMError1" xml:space="preserve">
-    <value>The user account has been deleted from the tenant directory. Ensure that the account with which the user tries to sign in is registered in Microsoft Entra ID.</value>
+    <value>Error : 3399614467. The user account has been deleted from the tenant directory. Ensure that the account with which the user tries to sign in is registered in Microsoft Entra ID.</value>
     <comment>Simplified error messages for WAM error 3399614467</comment>
   </data>
   <data name="DevBox_WAMError2" xml:space="preserve">
-    <value>Please refresh your multi-factor authentication. Account needs to be configured by the Microsoft Entra administrator with up-to-date MFA settings.</value>
+    <value>Error : 3399614476. Please refresh your multi-factor authentication. Account needs to be configured by the Microsoft Entra administrator with up-to-date MFA settings.</value>
     <comment>Simplified error messages for WAM error 3399614476</comment>
   </data>
   <data name="DevBox_WAMErrorRefer" xml:space="preserve">
     <value>For more details, please refer to https://learn.microsoft.com/en-us/entra/msal/dotnet/advanced/exceptions/wam-errors</value>
-    <comment>Redirect link to MS Learn page for additional info on WAM errors</comment>
+    <comment>{Locked="https://learn.microsoft.com/en-us/entra/msal/dotnet/advanced/exceptions/wam-errors"} Redirect link to MS Learn page for additional info on WAM errors</comment>
   </data>
 </root>

--- a/src/AzureExtension/Strings/en-US/Resources.resw
+++ b/src/AzureExtension/Strings/en-US/Resources.resw
@@ -734,4 +734,16 @@
     <value>Finding your pull requests. This may take several minutes.</value>
     <comment>Shown in Widget</comment>
   </data>
+  <data name="DevBox_WAMError1" xml:space="preserve">
+    <value>The user account has been deleted from the tenant directory. Ensure that the account with which the user tries to sign in is registered in Microsoft Entra ID.</value>
+    <comment>Simplified error messages for WAM error 3399614467</comment>
+  </data>
+  <data name="DevBox_WAMError2" xml:space="preserve">
+    <value>Please refresh your multi-factor authentication. Account needs to be configured by the Microsoft Entra administrator with up-to-date MFA settings.</value>
+    <comment>Simplified error messages for WAM error 3399614476</comment>
+  </data>
+  <data name="DevBox_WAMErrorRefer" xml:space="preserve">
+    <value>For more details, please refer to https://learn.microsoft.com/en-us/entra/msal/dotnet/advanced/exceptions/wam-errors</value>
+    <comment>Redirect link to MS Learn page for additional info on WAM errors</comment>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the pull request
1. Authentication issues produce error messages with PII redacted strings which when shown to the user is confusing. This PR simplifies the two most common ones and adds a link for more information for other such errors.
2. This PR also makes Dev Box instances aware that it's in a saving state. Currently firing a change state event to tell Dev Home the state has changed to 'saving' was occurring without actually updating the Dev Boxes state to saving. Which in turn resulted in a race condition that ended up showing duplicate pinning/unpinning operations on Dev Home.

## Validation steps performed
Manual

## PR checklist
- [ ] Closes #https://github.com/microsoft/devhome/issues/3691
- [ ] Part of the fix for https://github.com/microsoft/devhome/issues/3121

